### PR TITLE
feat(home): use live WASM terminal demos

### DIFF
--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'components/ui/terminal*.tsx'
       - 'scripts/build-registry.mjs'
+      - 'scripts/check-registry-boundaries.mjs'
   workflow_dispatch:
 
 permissions:
@@ -36,6 +37,9 @@ jobs:
       
       - name: Install dependencies
         run: bun install
+
+      - name: Check registry boundaries
+        run: bun run registry:check-boundaries
       
       - name: Build registry
         run: bun run registry:build

--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@
 
 Terminal UI components for React built with shadcn/ui and OpenTUI.
 
-## 🚀 Future Vision: True Web OpenTUI Runtime
+## Product Lanes
 
-This project is evolving from a React/DOM wrapper into a real, native OpenTUI WASM environment for the browser. Currently, `shadcn-opentui` uses a "dom-wrapper" strategy where components mimic the terminal using DOM elements (divs, spans). 
+- **Stable lane (default):** shadcn-installable components from the OpenTUI registry (`terminal`, `terminal-slider`, `terminal-controls`, CLI plugin helpers).
+- **Experimental lane (opt-in):** Zig + WASM runtime packages in `packages/web-core`, `packages/web-renderer`, and `packages/web-react`.
+
+If you are shipping an app, start with the stable shadcn lane. The WASM runtime is for experimentation and architecture validation.
+
+## Experimental: True Web OpenTUI Runtime
+
+This project is evolving from a React/DOM wrapper into a real, native OpenTUI WASM environment for the browser. Currently, `shadcn-opentui` uses a "dom-wrapper" strategy where components mimic the terminal using DOM elements (divs, spans).
 
 The new architecture introduces a true Zig-to-WASM rendering core so any OpenTUI app—not just terminal components—can run natively in the browser.
 
@@ -19,7 +26,7 @@ We are restructuring into a monorepo to separate the native web renderer from th
 - `packages/web-react`: The React reconciler target for the browser renderer (similar to `@opentui/react` but for web surfaces).
 - `apps/docs`: The shadcn UI wrapper and documentation site you see today.
 
-*Status: The Zig WASM proof-of-concept is built and running. Rendering surface APIs are under active development.*
+*Status: The Zig WASM proof-of-concept is built and running. Rendering surface APIs are under active development and should be treated as experimental.*
 
 ## Features
 
@@ -30,6 +37,8 @@ We are restructuring into a monorepo to separate the native web renderer from th
 - Theme support for light and dark modes
 
 ## Installation
+
+### Stable shadcn components (recommended)
 
 Add the registry to your `components.json`:
 
@@ -43,6 +52,14 @@ Install components:
 
 \`\`\`bash
 npx shadcn@latest add terminal
+\`\`\`
+
+### Experimental runtime packages (optional)
+
+Only needed if you are building against the WASM runtime directly:
+
+\`\`\`bash
+bun add @opentui/core @opentui/react
 \`\`\`
 
 ## Usage
@@ -68,7 +85,7 @@ bun install
 bun dev
 \`\`\`
 
-### Run the WASM runtime demo
+### Run the experimental WASM runtime demo
 
 \`\`\`bash
 bun run build:web-runtime

--- a/app/docs/examples/ascii/page.tsx
+++ b/app/docs/examples/ascii/page.tsx
@@ -2,12 +2,21 @@
 
 import Link from "next/link"
 import { ArrowRight, ImageIcon } from "lucide-react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { CodePreview } from "@/components/docs/code-preview"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Terminal as TerminalComponent } from "@/components/ui/terminal"
+
+const animationFrames = ["-", ".", "|", "/"]
+
+const asciiTemplates: Record<string, string[]> = {
+  rocket: ["   /|", "  /_|", " | ==|", " |___|"],
+  cat: [" /_/ ", "(o.o)", " >^< "],
+  ship: ["   |   ", " __|__ ", "/____/ "],
+}
 
 function AsciiPreview() {
   return (
@@ -29,19 +38,59 @@ function AsciiPreview() {
           description: "Show a predefined icon",
           handler: (args, context) => {
             const kind = args[0] || "rocket"
-            const icons: Record<string, string[]> = {
-              rocket: ["   /\\", "  /  \\", " | 🚀 |", " |____|"],
-              cat: [" /\_/\\", "( o.o )", " > ^ <"],
-            }
-            ;(icons[kind] || icons.rocket).forEach((line) => context?.addLine?.(line, "output"))
+            ;(asciiTemplates[kind] || asciiTemplates.rocket).forEach((line) => context?.addLine?.(line, "output"))
           },
         },
       }}
+      welcomeMessage={["ASCII Art Demo", "Try: ascii launch", "Try: art rocket"]}
+    />
+  )
+}
+
+function AnimatedStatusPreview() {
+  const [frameIndex, setFrameIndex] = useState(0)
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setFrameIndex((current) => (current + 1) % animationFrames.length)
+    }, 180)
+
+    return () => window.clearInterval(timer)
+  }, [])
+
+  return (
+    <TerminalComponent
+      key={frameIndex}
       welcomeMessage={[
-        "ASCII Art Demo",
-        "Try: ascii launch",
-        "Try: art rocket",
+        "Animated Status Demo",
+        `Rendering animation frame: ${animationFrames[frameIndex]}`,
+        `[${animationFrames[frameIndex]}] Building terminal animation...`,
       ]}
+      className="h-56"
+    />
+  )
+}
+
+function TemplateGalleryPreview() {
+  const [lastTemplate, setLastTemplate] = useState("rocket")
+
+  return (
+    <TerminalComponent
+      commands={{
+        art: {
+          name: "art",
+          description: "Render a predefined icon",
+          handler: (args, context) => {
+            const template = args[0] || "rocket"
+            const lines = asciiTemplates[template] || asciiTemplates.rocket
+            setLastTemplate(template)
+            context?.addLine?.(`Loaded template: ${template}`, "success")
+            lines.forEach((line) => context?.addLine?.(line, "output"))
+          },
+        },
+      }}
+      welcomeMessage={[`Last template: ${lastTemplate}`, "Try: art cat", "Try: art ship"]}
+      className="h-56"
     />
   )
 }
@@ -72,13 +121,14 @@ export function BannerTerminal() {
 const animationCode = `import { useEffect, useState } from "react"
 import { Terminal } from "@/components/ui/terminal"
 
+const animationFrames = ["-", ".", "|", "/"]
+
 export function AnimatedStatusTerminal() {
-  const frames = ["-", "\\", "|", "/"]
   const [frameIndex, setFrameIndex] = useState(0)
 
   useEffect(() => {
     const timer = window.setInterval(() => {
-      setFrameIndex((current) => (current + 1) % frames.length)
+      setFrameIndex((current) => (current + 1) % animationFrames.length)
     }, 180)
 
     return () => window.clearInterval(timer)
@@ -86,7 +136,12 @@ export function AnimatedStatusTerminal() {
 
   return (
     <Terminal
-      welcomeMessage={[\`Rendering animation frame: \${frames[frameIndex]}\`]}
+      key={frameIndex}
+      welcomeMessage={[
+        "Animated Status Demo",
+        \`Rendering animation frame: \${animationFrames[frameIndex]}\`,
+        \`[\${animationFrames[frameIndex]}] Building terminal animation...\`,
+      ]}
       className="h-56"
     />
   )
@@ -94,6 +149,12 @@ export function AnimatedStatusTerminal() {
 
 const interactiveCode = `import { useState } from "react"
 import { Terminal } from "@/components/ui/terminal"
+
+const asciiTemplates = {
+  rocket: ["   /|", "  /_|", " | ==|", " |___|"],
+  cat: [" /_/ ", "(o.o)", " >^< "],
+  ship: ["   |   ", " __|__ ", "/____/ "],
+}
 
 export function TemplateGalleryTerminal() {
   const [lastTemplate, setLastTemplate] = useState("rocket")
@@ -106,12 +167,14 @@ export function TemplateGalleryTerminal() {
           description: "Render a predefined icon",
           handler: (args, context) => {
             const template = args[0] || "rocket"
+            const lines = asciiTemplates[template] || asciiTemplates.rocket
             setLastTemplate(template)
             context?.addLine?.(\`Loaded template: \${template}\`, "success")
+            lines.forEach((line) => context?.addLine?.(line, "output"))
           },
         },
       }}
-      welcomeMessage={[\`Last template: \${lastTemplate}\`, "Try: art cat"]}
+      welcomeMessage={[\`Last template: \${lastTemplate}\`, "Try: art cat", "Try: art ship"]}
       className="h-56"
     />
   )
@@ -154,15 +217,30 @@ export default function AsciiExamplePage() {
             </TabsList>
 
             <TabsContent value="generator">
-              <CodePreview title="ASCII Text Generator" description="Render banners directly from a terminal command." code={generatorCode} preview={<AsciiPreview />} />
+              <CodePreview
+                title="ASCII Text Generator"
+                description="Render banners directly from a terminal command."
+                code={generatorCode}
+                preview={<AsciiPreview />}
+              />
             </TabsContent>
 
             <TabsContent value="animations">
-              <CodePreview title="Animated Status" description="Use React state to rotate simple ASCII frames." code={animationCode} />
+              <CodePreview
+                title="Animated Status"
+                description="Use React state to rotate simple ASCII frames."
+                code={animationCode}
+                preview={<AnimatedStatusPreview />}
+              />
             </TabsContent>
 
             <TabsContent value="interactive">
-              <CodePreview title="Template Gallery" description="Track reusable art templates in React state and render them from commands." code={interactiveCode} />
+              <CodePreview
+                title="Template Gallery"
+                description="Track reusable art templates in React state and render them from commands."
+                code={interactiveCode}
+                preview={<TemplateGalleryPreview />}
+              />
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/app/docs/installation/page.tsx
+++ b/app/docs/installation/page.tsx
@@ -1,4 +1,4 @@
-import { Package, Download, CheckCircle } from "lucide-react"
+import { CheckCircle } from "lucide-react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { CodePreview } from "@/components/docs/code-preview"
@@ -10,12 +10,9 @@ export default function InstallationPage() {
     <div className="space-y-8">
       <div className="space-y-4">
         <h1 className="text-4xl font-bold tracking-tight">Installation</h1>
-          <p className="text-xl text-muted-foreground">
-            Get started with the shadcn terminal component using a single command.
-          </p>
-        </div>
+        <p className="text-xl text-muted-foreground">Get started with the shadcn terminal component using a single command.</p>
+      </div>
 
-        {/* Prerequisites */}
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -31,7 +28,6 @@ export default function InstallationPage() {
           </CardContent>
         </Card>
 
-        {/* Prerequisites */}
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -82,6 +78,22 @@ export default function InstallationPage() {
 
         <OpenTUIRuntimeStatusCard />
 
+      <details className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-4">
+        <summary className="cursor-pointer list-none font-medium text-foreground">
+          Experimental runtime packages (optional)
+        </summary>
+        <div className="mt-3 space-y-3 text-sm text-muted-foreground">
+          <p>
+            Stable shadcn component usage is the default path for production apps. Use the runtime lane only if you want to
+            experiment with the Zig/WASM browser core.
+          </p>
+          <div className="bg-background/70 rounded-md p-3 border border-amber-500/20">
+            <code className="text-sm block">bun add @opentui/core @opentui/react</code>
+          </div>
+          <p>These packages are intentionally labeled experimental because the rendering APIs are still evolving.</p>
+        </div>
+      </details>
+
       {/* Verification */}
       <Card>
         <CardHeader>
@@ -130,13 +142,14 @@ export default function TestPage() {
             <div>
               <h4 className="font-semibold text-sm">JSX element errors</h4>
               <p className="text-sm text-muted-foreground">
-                Ensure your tsconfig.json has the correct jsxImportSource setting pointing to "@opentui/react".
+                If you are only using shadcn components, you do not need a custom jsxImportSource. Keep your default Next.js setup.
               </p>
             </div>
             <div>
               <h4 className="font-semibold text-sm">Module not found errors</h4>
               <p className="text-sm text-muted-foreground">
-                Verify all required packages are installed: @opentui/react, @opentui/core, and react.
+                For stable component usage, ensure your registry install completed. For experimental runtime usage, also install
+                @opentui/react and @opentui/core.
               </p>
             </div>
           </div>

--- a/app/docs/labs/page.tsx
+++ b/app/docs/labs/page.tsx
@@ -1,0 +1,55 @@
+import { ArrowRight, FlaskConical, Terminal } from "lucide-react"
+import Link from "next/link"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { OpenTUIRuntimeStatusCard } from "@/components/opentui/runtime-status-card"
+
+export default function LabsPage() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <FlaskConical className="h-8 w-8 text-amber-500" />
+          <h1 className="text-4xl font-bold tracking-tight">Experimental</h1>
+        </div>
+        <p className="text-xl text-muted-foreground max-w-2xl">
+          This section covers the Zig/WASM runtime lane. Use it to explore browser-native rendering, not as the default
+          path for shadcn component installs.
+        </p>
+      </div>
+
+      <OpenTUIRuntimeStatusCard />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <Card className="border-amber-500/20 bg-amber-500/5">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Terminal className="h-5 w-5" />
+              WASM Runtime
+            </CardTitle>
+            <CardDescription>Understand the Zig core, renderer, and React bridge</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="outline">
+              <Link href="/docs/labs/wasm-runtime" className="flex items-center gap-2">
+                Open runtime notes
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Stable lane reminder</CardTitle>
+            <CardDescription>Shadcn components remain the recommended default</CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground space-y-2">
+            <p>Install registry components when you want a production-ready browser terminal UI.</p>
+            <p>Reach for the experimental runtime only when you need to validate the browser-native OpenTUI path.</p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/docs/labs/wasm-runtime/page.tsx
+++ b/app/docs/labs/wasm-runtime/page.tsx
@@ -1,0 +1,70 @@
+import { Code2, Download, FlaskConical, Terminal } from "lucide-react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { CodeBlock } from "@/components/docs/code-block"
+
+export default function WasmRuntimePage() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <FlaskConical className="h-8 w-8 text-amber-500" />
+          <h1 className="text-4xl font-bold tracking-tight">WASM Runtime</h1>
+        </div>
+        <p className="text-xl text-muted-foreground max-w-3xl">
+          The experimental Zig/WASM lane powers the browser runtime. It is separate from the shadcn component surface and may
+          change as the rendering APIs evolve.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="outline">Experimental</Badge>
+          <Badge variant="outline">Zig</Badge>
+          <Badge variant="outline">WASM</Badge>
+          <Badge variant="outline">Browser runtime</Badge>
+        </div>
+      </div>
+
+      <Card className="border-amber-500/20 bg-amber-500/5">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Download className="h-5 w-5" />
+            Optional install
+          </CardTitle>
+          <CardDescription>Only needed if you are testing the runtime packages directly</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <CodeBlock code={`bun add @opentui/core @opentui/react`} language="bash" showLineNumbers={false} />
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Code2 className="h-5 w-5" />
+              What it is for
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground space-y-2">
+            <p>Validating browser-native rendering for OpenTUI apps.</p>
+            <p>Testing the Zig buffer, Canvas renderer, and React reconciler split.</p>
+            <p>Exploring a path beyond the shadcn component wrapper.</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Terminal className="h-5 w-5" />
+              What to avoid
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground space-y-2">
+            <p>Do not depend on these packages for the normal shadcn install path.</p>
+            <p>Do not import `packages/web-*` directly from registry components.</p>
+            <p>Expect APIs to change while the runtime is still being validated.</p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -57,6 +57,13 @@ const navigation = [
       { title: "ASCII Art", href: "/docs/examples/ascii", icon: Terminal },
     ],
   },
+  {
+    title: "Experimental",
+    items: [
+      { title: "WASM Runtime", href: "/docs/labs/wasm-runtime", icon: Zap },
+      { title: "Experimental Overview", href: "/docs/labs", icon: FileText },
+    ],
+  },
 ]
 
 export default function DocsLayout({

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -193,6 +193,21 @@ function App() {
             </Button>
           </CardContent>
         </Card>
+
+        <Card className="hover:shadow-md transition-shadow border-amber-500/20 bg-amber-500/5">
+          <CardHeader>
+            <CardTitle className="text-lg">Experimental Runtime</CardTitle>
+            <CardDescription>Zig/WASM internals and browser runtime experiments</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="ghost" className="p-0 h-auto">
+              <Link href="/docs/labs" className="flex items-center gap-2">
+                Explore labs
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
       </div>
     </div>
   )

--- a/app/docs/quick-start/page.tsx
+++ b/app/docs/quick-start/page.tsx
@@ -116,6 +116,10 @@ export default function MyTerminal() {
 
         <div className="space-y-4">
           <h3 className="text-lg font-semibold">What's included?</h3>
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-muted-foreground">
+            This quick start uses the <strong className="text-foreground">stable shadcn component lane</strong>. The Zig/WASM runtime
+            packages are optional and intended for experimental builds.
+          </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <Card>
               <CardHeader>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,7 @@ import Link from "next/link"
 import { useState } from "react"
 import { MatrixRain } from "@/components/matrix-rain"
 import { OpenTUIRuntimeStatusCard } from "@/components/opentui/runtime-status-card"
-import { WasmTerminal } from "@/components/opentui/wasm-terminal"
+import { Terminal } from "@/components/ui/terminal"
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
@@ -40,14 +40,24 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
-function WasmDemoCard({ title, description }: { title: string; description: string }) {
+function TerminalDemoCard({
+  title,
+  description,
+  commands,
+  welcomeMessage,
+}: {
+  title: string
+  description: string
+  commands: Record<string, CommandHandler>
+  welcomeMessage: string[]
+}) {
   return (
     <div className="rounded-lg border border-primary/30 bg-black shadow-lg shadow-primary/10 overflow-hidden">
       <div className="flex items-center justify-between border-b border-primary/20 bg-black/80 px-4 py-2.5">
-        <span className="text-xs font-mono font-semibold text-primary">OpenTUI WASM</span>
+        <span className="text-xs font-mono font-semibold text-primary">shadcn OpenTUI</span>
         <span className="text-xs font-mono text-primary/50">{title}</span>
       </div>
-      <WasmTerminal className="h-[260px] bg-black" />
+      <Terminal commands={commands} welcomeMessage={welcomeMessage} className="h-[260px] bg-black" />
       <div className="border-t border-primary/20 bg-black/80 px-4 py-2 text-xs text-primary/70">{description}</div>
     </div>
   )
@@ -264,18 +274,69 @@ export default function Home() {
           </div>
         </section>
 
-        {/* Animated Demos - Using OpenTUI Terminal */}
+        {/* Animated Demos - Using the shadcn OpenTUI Terminal */}
         <section className="py-20 px-6">
           <div className="max-w-7xl mx-auto">
             <div className="text-center mb-16">
               <h2 className="text-3xl md:text-4xl font-bold mb-4 text-foreground">See it in action</h2>
-                <p className="text-muted-foreground text-lg">Live OpenTUI WASM terminals running in the browser (experimental lane)</p>
+                <p className="text-muted-foreground text-lg">Live shadcn terminal components running in the browser</p>
               </div>
 
               <div className="grid md:grid-cols-3 gap-6">
-                <WasmDemoCard title="Installation" description="Core + renderer + React reconciler wired to wasm32 runtime." />
-                <WasmDemoCard title="UI Components" description="Interactive terminal primitives rendered from the shared buffer." />
-                <WasmDemoCard title="Built-in Commands" description="Canvas cells are driven directly by the OpenTUI wasm core." />
+                <TerminalDemoCard
+                  title="Installation"
+                  description="Install and validate the stable shadcn terminal component."
+                  commands={{
+                    install: {
+                      name: "install",
+                      description: "Show install command",
+                      handler: (_args, context) => {
+                        context?.addLine?.("bunx shadcn@latest add terminal", "success")
+                        context?.addLine?.("Registry component ready.")
+                      },
+                    },
+                  }}
+                  welcomeMessage={["Install demo", "Try: install"]}
+                />
+                <TerminalDemoCard
+                  title="UI Components"
+                  description="Open forms and menus inside the stable terminal surface."
+                  commands={{
+                    menu: {
+                      name: "menu",
+                      description: "Open a menu",
+                      handler: (_args, context) => {
+                        context?.setState?.((prev: { menuSelection: number }) => ({
+                          ...prev,
+                          mode: "ui",
+                          menuSelection: 0,
+                          activeComponent: {
+                            id: `demo-menu-${Date.now()}`,
+                            type: "menu",
+                            props: { items: ["Dashboard", "Projects", "Settings"] },
+                            active: true,
+                          },
+                        }))
+                      },
+                    },
+                  }}
+                  welcomeMessage={["UI demo", "Try: menu"]}
+                />
+                <TerminalDemoCard
+                  title="Built-in Commands"
+                  description="Command history, completions, async handlers, and terminal output."
+                  commands={{
+                    status: {
+                      name: "status",
+                      description: "Show status",
+                      handler: (_args, context) => {
+                        context?.addLine?.("Terminal mounted", "success")
+                        context?.addLine?.("Commands active: help, clear, status")
+                      },
+                    },
+                  }}
+                  welcomeMessage={["Commands demo", "Try: status", "Try: help"]}
+                />
               </div>
             </div>
           </section>
@@ -469,7 +530,10 @@ export default function Home() {
               </div>
 
               <div className="rounded-xl border border-primary/20 overflow-hidden shadow-xl shadow-primary/10">
-                <WasmTerminal className="h-[500px] bg-black" />
+                <Terminal
+                  className="h-[500px] bg-black"
+                  welcomeMessage={["Interactive shadcn terminal", "Try: help", "Try: menu Dashboard Projects Settings"]}
+                />
               </div>
             </div>
           </div>
@@ -542,7 +606,7 @@ export default function Home() {
 function TerminalScenarioCard({
   title,
   description,
-  commands: _commands,
+  commands,
   welcomeMessage,
 }: {
   title: string
@@ -556,7 +620,7 @@ function TerminalScenarioCard({
         <h3 className="text-lg font-semibold text-foreground">{title}</h3>
         <p className="mt-1 text-sm text-muted-foreground">{description}</p>
       </div>
-      <WasmTerminal className="h-64 bg-black" />
+      <Terminal commands={commands} welcomeMessage={welcomeMessage} className="h-64 bg-black" />
       <div className="space-y-1 border-t border-primary/10 pt-3 text-xs text-primary/70">
         {welcomeMessage.map((message) => (
           <p key={message}>{message}</p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -97,9 +97,9 @@ function RegistrySetupBlock() {
       description: "Install the main OpenTUI terminal component",
     },
     {
-      title: "Install official OpenTUI packages",
+      title: "Optional: install experimental runtime",
       command: "bun add @opentui/core @opentui/react",
-      description: "Keep the browser terminal aligned with the official OpenTUI package boundary.",
+      description: "Only needed when testing the Zig/WASM runtime lane. Not required for standard shadcn component usage.",
     },
   ]
 
@@ -269,7 +269,7 @@ export default function Home() {
           <div className="max-w-7xl mx-auto">
             <div className="text-center mb-16">
               <h2 className="text-3xl md:text-4xl font-bold mb-4 text-foreground">See it in action</h2>
-                <p className="text-muted-foreground text-lg">Live OpenTUI WASM terminals running in the browser</p>
+                <p className="text-muted-foreground text-lg">Live OpenTUI WASM terminals running in the browser (experimental lane)</p>
               </div>
 
               <div className="grid md:grid-cols-3 gap-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import type React from "react"
-import { Terminal } from "@/components/ui/terminal"
 import { Command } from "@/components/command"
 import type { CommandHandler } from "@/lib/types"
 import { Button } from "@/components/ui/button"
@@ -20,7 +19,7 @@ import {
   WandSparkles,
 } from "lucide-react"
 import Link from "next/link"
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { MatrixRain } from "@/components/matrix-rain"
 import { OpenTUIRuntimeStatusCard } from "@/components/opentui/runtime-status-card"
 import { WasmTerminal } from "@/components/opentui/wasm-terminal"
@@ -41,103 +40,15 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
-function OpenTUITerminalDemo({
-  title,
-  script,
-}: {
-  title: string
-  script: Array<{ command: string; output: string[]; delay: number }>
-}) {
-  const [lines, setLines] = useState<Array<{ type: string; content: string }>>([])
-  const [currentStep, setCurrentStep] = useState(0)
-  const [typedCommand, setTypedCommand] = useState("")
-  const [isTyping, setIsTyping] = useState(false)
-
-  useEffect(() => {
-    if (currentStep >= script.length) {
-      const resetTimer = setTimeout(() => {
-        setLines([])
-        setCurrentStep(0)
-        setTypedCommand("")
-      }, 5000)
-      return () => clearTimeout(resetTimer)
-    }
-
-    const step = script[currentStep]
-    setIsTyping(true)
-    setTypedCommand("")
-
-    let charIndex = 0
-    const typeInterval = setInterval(() => {
-      if (charIndex < step.command.length) {
-        setTypedCommand(step.command.slice(0, charIndex + 1))
-        charIndex++
-      } else {
-        clearInterval(typeInterval)
-        setIsTyping(false)
-
-        setTimeout(() => {
-          setLines((prev) => [...prev, { type: "command", content: step.command }])
-          step.output.forEach((output, i) => {
-            setTimeout(() => {
-              setLines((prev) => [
-                ...prev,
-                { type: output.startsWith("✓") || output.startsWith("✔") ? "success" : "output", content: output },
-              ])
-            }, i * 150)
-          })
-          setTypedCommand("")
-          setTimeout(() => setCurrentStep((prev) => prev + 1), step.delay)
-        }, 200)
-      }
-    }, 50)
-
-    return () => clearInterval(typeInterval)
-  }, [currentStep, script])
-
+function WasmDemoCard({ title, description }: { title: string; description: string }) {
   return (
-    <div className="bg-black border border-primary/30 rounded-lg overflow-hidden shadow-lg shadow-primary/10">
-      {/* OpenTUI Terminal Header */}
-      <div className="flex items-center justify-between px-4 py-2.5 border-b border-primary/20 bg-black/80">
-        <div className="flex items-center gap-2">
-          <div className="flex gap-1.5">
-            <div className="w-3 h-3 rounded-full bg-red-500/80" />
-            <div className="w-3 h-3 rounded-full bg-yellow-500/80" />
-            <div className="w-3 h-3 rounded-full bg-green-500/80" />
-          </div>
-          <span className="text-xs text-primary font-mono font-semibold ml-2">OpenTUI Terminal</span>
-        </div>
-        <span className="text-xs text-primary/50 font-mono">{title}</span>
+    <div className="rounded-lg border border-primary/30 bg-black shadow-lg shadow-primary/10 overflow-hidden">
+      <div className="flex items-center justify-between border-b border-primary/20 bg-black/80 px-4 py-2.5">
+        <span className="text-xs font-mono font-semibold text-primary">OpenTUI WASM</span>
+        <span className="text-xs font-mono text-primary/50">{title}</span>
       </div>
-
-      {/* Terminal Body */}
-      <div className="p-4 font-mono text-sm h-[260px] overflow-hidden bg-black">
-        {lines.map((line, i) => (
-          <div key={i} className="leading-relaxed">
-            {line.type === "command" ? (
-              <span>
-                <span className="text-primary font-bold">user@opentui:~$</span>{" "}
-                <span className="text-white">{line.content}</span>
-              </span>
-            ) : (
-              <span className={line.type === "success" ? "text-primary" : "text-primary/70"}>{line.content}</span>
-            )}
-          </div>
-        ))}
-        {isTyping && (
-          <div className="leading-relaxed">
-            <span className="text-primary font-bold">user@opentui:~$</span>{" "}
-            <span className="text-white">{typedCommand}</span>
-            <span className="animate-pulse text-primary">█</span>
-          </div>
-        )}
-        {!isTyping && currentStep < script.length && (
-          <div className="leading-relaxed">
-            <span className="text-primary font-bold">user@opentui:~$</span>
-            <span className="animate-pulse text-primary ml-1">█</span>
-          </div>
-        )}
-      </div>
+      <WasmTerminal className="h-[260px] bg-black" />
+      <div className="border-t border-primary/20 bg-black/80 px-4 py-2 text-xs text-primary/70">{description}</div>
     </div>
   )
 }
@@ -225,78 +136,6 @@ function RegistrySetupBlock() {
 }
 
 export default function Home() {
-  const customCommands: Record<string, CommandHandler> = {
-    echo: {
-      name: "echo",
-      description: "Echo text to output",
-      handler: (args, context) => context?.addLine?.(args.join(" ") || "Nothing to echo", "success"),
-    },
-    whoami: {
-      name: "whoami",
-      description: "Display current user",
-      handler: (_args, context) => context?.addLine?.("guest@opentui", "output"),
-    },
-    pwd: {
-      name: "pwd",
-      description: "Print working directory",
-      handler: (_args, context) => context?.addLine?.("/workspace/opentui-demo", "output"),
-    },
-    ls: {
-      name: "ls",
-      description: "List directory contents",
-      handler: (_args, context) => context?.addLine?.("app  components  lib  public", "output"),
-    },
-    ui: { name: "ui", description: "Enter UI mode", handler: () => {} },
-    form: { name: "form", description: "Create interactive form", handler: () => {} },
-    menu: { name: "menu", description: "Create interactive menu", handler: () => {} },
-    progress: { name: "progress", description: "Show progress bar", handler: () => {} },
-    ascii: { name: "ascii", description: "Generate ASCII art", handler: () => {} },
-  }
-
-  const demoScript1 = [
-    {
-      command: "npx shadcn@latest add https://opentui.vercel.app/r/terminal.json",
-      output: ["Installing @opentui/core and @opentui/react...", "✓ Browser wrapper wired to OpenTUI packages"],
-      delay: 2000,
-    },
-    {
-      command: "npm run dev",
-      output: ["Starting development server...", "✓ Ready on localhost:3000"],
-      delay: 2500,
-    },
-  ]
-
-  const demoScript2 = [
-    {
-      command: "ui menu Dashboard Settings Logout",
-      output: ["Creating menu with options...", "► Dashboard", "  Settings", "  Logout"],
-      delay: 2500,
-    },
-    {
-      command: "form username email password",
-      output: ["Creating form...", "✓ Form ready - TAB to navigate"],
-      delay: 2000,
-    },
-  ]
-
-  const demoScript3 = [
-    {
-      command: "ascii HELLO",
-      output: [
-        "Generating ASCII art...",
-        "██   ██ ███████ ██      ██       ██████",
-        "██   ██ ██      ██      ██      ██    ██",
-        "███████ █████   ██      ██      ██    ██",
-      ],
-      delay: 3000,
-    },
-    {
-      command: "progress 2000",
-      output: ["[████████████░░░░░░░░] 60%", "✓ Progress complete!"],
-      delay: 2500,
-    },
-  ]
-
   return (
     <div className="min-h-screen relative overflow-hidden">
       {/* Matrix Rain Background */}
@@ -430,26 +269,16 @@ export default function Home() {
           <div className="max-w-7xl mx-auto">
             <div className="text-center mb-16">
               <h2 className="text-3xl md:text-4xl font-bold mb-4 text-foreground">See it in action</h2>
-              <p className="text-muted-foreground text-lg">
-                Watch automated demos showcasing OpenTUI terminal features
-              </p>
-            </div>
+                <p className="text-muted-foreground text-lg">Live OpenTUI WASM terminals running in the browser</p>
+              </div>
 
-            <div className="grid md:grid-cols-3 gap-6">
-              <OpenTUITerminalDemo title="Installation" script={[{
-                command: "npx shadcn@latest add https://opentui.vercel.app/r/terminal.json",
-                output: ["Installing @opentui/core and @opentui/react...", "✓ Browser wrapper wired to OpenTUI packages"],
-                delay: 2000,
-              }, {
-                command: "npm run dev",
-                output: ["Starting development server...", "✓ Ready on localhost:3000"],
-                delay: 2500,
-              }]} />
-              <OpenTUITerminalDemo title="UI Components" script={demoScript2} />
-              <OpenTUITerminalDemo title="Built-in Commands" script={demoScript3} />
+              <div className="grid md:grid-cols-3 gap-6">
+                <WasmDemoCard title="Installation" description="Core + renderer + React reconciler wired to wasm32 runtime." />
+                <WasmDemoCard title="UI Components" description="Interactive terminal primitives rendered from the shared buffer." />
+                <WasmDemoCard title="Built-in Commands" description="Canvas cells are driven directly by the OpenTUI wasm core." />
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
 
         <section className="py-20 px-6 border-y border-primary/10 bg-black/20">
           <div className="max-w-7xl mx-auto">
@@ -713,7 +542,7 @@ export default function Home() {
 function TerminalScenarioCard({
   title,
   description,
-  commands,
+  commands: _commands,
   welcomeMessage,
 }: {
   title: string
@@ -727,7 +556,12 @@ function TerminalScenarioCard({
         <h3 className="text-lg font-semibold text-foreground">{title}</h3>
         <p className="mt-1 text-sm text-muted-foreground">{description}</p>
       </div>
-      <Terminal commands={commands} welcomeMessage={welcomeMessage} className="h-64 bg-black" />
+      <WasmTerminal className="h-64 bg-black" />
+      <div className="space-y-1 border-t border-primary/10 pt-3 text-xs text-primary/70">
+        {welcomeMessage.map((message) => (
+          <p key={message}>{message}</p>
+        ))}
+      </div>
     </div>
   )
 }

--- a/components/docs/breadcrumb-nav.tsx
+++ b/components/docs/breadcrumb-nav.tsx
@@ -43,6 +43,15 @@ export function BreadcrumbNav() {
             const exampleName = segments[2].charAt(0).toUpperCase() + segments[2].slice(1)
             breadcrumbs.push({ label: exampleName, href: `/docs/examples/${segments[2]}` })
           }
+        } else if (segments[1] === "labs") {
+          breadcrumbs.push({ label: "Experimental", href: "/docs/labs" })
+          if (segments[2]) {
+            const pageName = segments[2]
+              .split("-")
+              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+              .join(" ")
+            breadcrumbs.push({ label: pageName, href: `/docs/labs/${segments[2]}` })
+          }
         } else {
           // Handle direct pages like installation, quick-start
           const pageName = segments[1]

--- a/components/docs/interactive-examples.tsx
+++ b/components/docs/interactive-examples.tsx
@@ -1,90 +1,259 @@
 "use client"
 
-import Link from "next/link"
-import { ArrowRight, ImageIcon, LogIn, Menu, PlayCircle } from "lucide-react"
+import { Code2, FileText, ImageIcon, LogIn, Menu, Monitor, SlidersHorizontal, Timer } from "lucide-react"
+import type React from "react"
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Terminal } from "@/components/ui/terminal"
+import type { CommandHandler } from "@/lib/types"
 
-const examplePages = [
+type Example = {
+  value: string
+  label: string
+  title: string
+  description: string
+  status: string
+  icon: React.ElementType
+  welcomeMessage: string[]
+  commands: Record<string, CommandHandler>
+}
+
+const examples: Example[] = [
   {
-    title: "Login Flow",
-    description: "A terminal-driven sign-in demo with forms, validation, and success states.",
-    href: "/docs/examples/login",
+    value: "login",
+    label: "Login",
+    title: "Login Form Example",
+    description: "Interactive login simulation. Try: login admin secret",
+    status: "idle",
     icon: LogIn,
-    badge: "Forms",
-    preview: (
-      <Terminal
-        commands={{
-          login: {
-            name: "login",
-            description: "Show a success message",
-            handler: (_args, context) => {
-              context?.addLine?.("Signed in as demo-user.", "success")
-            },
-          },
-        }}
-        welcomeMessage={["Login demo", "Try: login"]}
-        className="h-40"
-      />
-    ),
+    welcomeMessage: ["Login Terminal Demo", "Try: login admin secret", "Type 'help' for all commands"],
+    commands: {
+      login: {
+        name: "login",
+        description: "Validate a username and password",
+        handler: (args, context) => {
+          const [username, password] = args
+          if (username === "admin" && password === "secret") {
+            context?.addLine?.("Authentication successful", "success")
+            context?.addLine?.("Welcome back, admin.", "output")
+            return
+          }
+
+          context?.addLine?.("Invalid credentials. Try: login admin secret", "error")
+        },
+      },
+    },
   },
   {
-    title: "Interactive Menu",
-    description: "Keyboard-driven menus with nested actions and command routing.",
-    href: "/docs/examples/menu",
+    value: "menu",
+    label: "Menu",
+    title: "Interactive Menu Example",
+    description: "Open a keyboard-driven menu. Try: menu",
+    status: "ready",
     icon: Menu,
-    badge: "Navigation",
-    preview: (
-      <Terminal
-        commands={{
-          menu: {
-            name: "menu",
-            description: "Open the menu",
-            handler: (_args, context) => {
-              context?.setState?.((prev: { menuSelection: number }) => ({
-                ...prev,
-                mode: "ui",
-                menuSelection: 0,
-                activeComponent: {
-                  id: `menu-${Date.now()}`,
-                  type: "menu",
-                  props: { items: ["Dashboard", "Projects", "Settings"] },
-                  active: true,
-                },
-              }))
+    welcomeMessage: ["Menu Terminal Demo", "Try: menu", "Use arrow keys after opening the menu"],
+    commands: {
+      menu: {
+        name: "menu",
+        description: "Open an interactive menu",
+        handler: (_args, context) => {
+          context?.setState?.((prev: { menuSelection: number }) => ({
+            ...prev,
+            mode: "ui",
+            menuSelection: 0,
+            activeComponent: {
+              id: `menu-${Date.now()}`,
+              type: "menu",
+              props: { items: ["Dashboard", "Projects", "Deployments", "Settings"] },
+              active: true,
             },
-          },
-        }}
-        welcomeMessage={["Menu demo", "Try: menu"]}
-        className="h-40"
-      />
-    ),
+          }))
+        },
+      },
+    },
   },
   {
-    title: "ASCII Studio",
-    description: "Generate banners, badges, and text art directly inside the terminal.",
-    href: "/docs/examples/ascii",
+    value: "ascii",
+    label: "ASCII",
+    title: "ASCII Art Example",
+    description: "Generate terminal banners. Try: ascii opentui",
+    status: "creative",
     icon: ImageIcon,
-    badge: "Styling",
-    preview: (
-      <Terminal
-        commands={{
-          ascii: {
-            name: "ascii",
-            description: "Generate a banner",
-            handler: (args, context) => {
-              const label = (args.join(" ") || "OpenTUI").toUpperCase()
-              context?.addLine?.(`### ${label} ###`, "success")
-            },
-          },
-        }}
-        welcomeMessage={["ASCII demo", "Try: ascii launch"]}
-        className="h-40"
-      />
-    ),
+    welcomeMessage: ["ASCII Terminal Demo", "Try: ascii opentui", "Try: box launch"],
+    commands: {
+      ascii: {
+        name: "ascii",
+        description: "Generate a simple banner",
+        handler: (args, context) => {
+          const label = (args.join(" ") || "OpenTUI").toUpperCase().slice(0, 18)
+          context?.addLine?.("+--------------------+", "success")
+          context?.addLine?.(`| ${label.padEnd(18, " ")} |`, "success")
+          context?.addLine?.("+--------------------+", "success")
+        },
+      },
+      box: {
+        name: "box",
+        description: "Draw a boxed label",
+        handler: (args, context) => {
+          const label = args.join(" ") || "launch"
+          context?.addLine?.(`[ ${label} ]`, "success")
+        },
+      },
+    },
+  },
+  {
+    value: "counter",
+    label: "Counter",
+    title: "Counter Example",
+    description: "Increment and reset a counter. Try: inc",
+    status: "0",
+    icon: Timer,
+    welcomeMessage: ["Counter Terminal Demo", "Try: inc", "Try: reset"],
+    commands: {
+      inc: {
+        name: "inc",
+        description: "Increment a demo counter",
+        handler: (_args, context) => {
+          const count = Number(context?.state?.formData?.count ?? 0) + 1
+          context?.setState?.((prev: { formData: Record<string, string> }) => ({
+            ...prev,
+            formData: { ...prev.formData, count: String(count) },
+          }))
+          context?.addLine?.(`Counter: ${count}`, "success")
+        },
+      },
+      reset: {
+        name: "reset",
+        description: "Reset the demo counter",
+        handler: (_args, context) => {
+          context?.setState?.((prev: { formData: Record<string, string> }) => ({ ...prev, formData: { ...prev.formData, count: "0" } }))
+          context?.addLine?.("Counter reset to 0", "success")
+        },
+      },
+    },
+  },
+  {
+    value: "monitor",
+    label: "Monitor",
+    title: "System Monitor Example",
+    description: "Render a compact system dashboard. Try: status",
+    status: "live",
+    icon: Monitor,
+    welcomeMessage: ["Monitor Terminal Demo", "Try: status", "Try: deploy"],
+    commands: {
+      status: {
+        name: "status",
+        description: "Show system status",
+        handler: (_args, context) => {
+          context?.addLine?.("System status", "success")
+          context?.addLine?.("CPU    [####......] 42%")
+          context?.addLine?.("Memory [######....] 61%")
+          context?.addLine?.("Network 842 Mbps")
+        },
+      },
+      deploy: {
+        name: "deploy",
+        description: "Animate deployment progress",
+        handler: async (_args, context) => {
+          context?.addLine?.("Deploying preview...", "success")
+          context?.addLine?.("Deploy [..........] 0%")
+          for (let step = 1; step <= 10; step += 1) {
+            context?.updateLastLine?.(`Deploy [${"#".repeat(step)}${".".repeat(10 - step)}] ${step * 10}%`)
+            await new Promise((resolve) => setTimeout(resolve, 120))
+          }
+          context?.addLine?.("Deploy complete", "success")
+        },
+      },
+    },
+  },
+  {
+    value: "files",
+    label: "Files",
+    title: "File Browser Example",
+    description: "Explore a terminal-style file list. Try: ls",
+    status: "4 files",
+    icon: FileText,
+    welcomeMessage: ["Files Terminal Demo", "Try: ls", "Try: open package.json"],
+    commands: {
+      ls: {
+        name: "ls",
+        description: "List demo files",
+        handler: (_args, context) => {
+          context?.addLine?.("demo/", "success")
+          context?.addLine?.("  package.json")
+          context?.addLine?.("  components.json")
+          context?.addLine?.("  app/docs/page.tsx")
+          context?.addLine?.("  components/ui/terminal.tsx")
+        },
+      },
+      open: {
+        name: "open",
+        description: "Open a demo file",
+        handler: (args, context) => {
+          const file = args.join(" ") || "package.json"
+          context?.addLine?.(`Opened ${file}`, "success")
+          context?.addLine?.("Read-only preview loaded inside the terminal.")
+        },
+      },
+    },
+  },
+  {
+    value: "controls",
+    label: "Controls",
+    title: "Terminal Controls Example",
+    description: "Drive control-like state through commands. Try: volume 75",
+    status: "50%",
+    icon: SlidersHorizontal,
+    welcomeMessage: ["Controls Terminal Demo", "Try: volume 75", "Try: theme dark"],
+    commands: {
+      volume: {
+        name: "volume",
+        description: "Set a demo volume percentage",
+        handler: (args, context) => {
+          const value = Math.max(0, Math.min(100, Number(args[0]) || 50))
+          const filled = Math.round(value / 10)
+          context?.addLine?.(`Volume [${"#".repeat(filled)}${".".repeat(10 - filled)}] ${value}%`, "success")
+        },
+      },
+      theme: {
+        name: "theme",
+        description: "Switch a named theme",
+        handler: (args, context) => {
+          context?.addLine?.(`Theme set to ${args[0] || "dark"}`, "success")
+        },
+      },
+    },
+  },
+  {
+    value: "devtools",
+    label: "DevTools",
+    title: "DevTools Example",
+    description: "Inspect commands and debug output. Try: inspect",
+    status: "debug",
+    icon: Code2,
+    welcomeMessage: ["DevTools Terminal Demo", "Try: inspect", "Try: logs"],
+    commands: {
+      inspect: {
+        name: "inspect",
+        description: "Inspect the terminal runtime state",
+        handler: (_args, context) => {
+          context?.addLine?.("Terminal state", "success")
+          context?.addLine?.(`mode: ${context?.state?.mode ?? "command"}`)
+          context?.addLine?.(`activeComponent: ${context?.state?.activeComponent?.type ?? "none"}`)
+        },
+      },
+      logs: {
+        name: "logs",
+        description: "Show sample debug logs",
+        handler: (_args, context) => {
+          context?.addLine?.("[debug] command registry loaded")
+          context?.addLine?.("[debug] input focus active")
+          context?.addLine?.("[debug] shadcn terminal renderer mounted", "success")
+        },
+      },
+    },
   },
 ]
 
@@ -92,56 +261,46 @@ export function InteractiveExamples() {
   return (
     <div className="space-y-8">
       <div className="space-y-4">
-        <div className="flex items-center gap-3">
-          <div className="rounded-xl bg-emerald-500/15 p-2 text-emerald-300">
-            <PlayCircle className="h-6 w-6" />
-          </div>
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight">Interactive Examples</h1>
-            <p className="text-muted-foreground">Real demos you can explore before integrating the component.</p>
-          </div>
-        </div>
-
-        <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4 text-sm text-muted-foreground">
-          Each example page includes a live OpenTUI preview, implementation notes, and working code samples.
-        </div>
+        <h1 className="text-3xl font-bold tracking-tight">Interactive Examples</h1>
+        <p className="max-w-3xl text-muted-foreground">
+          Explore OpenTUI React capabilities through these interactive terminal examples. Each demo uses the stable shadcn
+          terminal component and showcases a different terminal UI pattern.
+        </p>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-        {examplePages.map((page) => {
-          const Icon = page.icon
+      <Tabs defaultValue="login" className="space-y-8">
+        <TabsList className="grid h-auto w-full grid-cols-2 rounded-xl bg-muted/60 p-1 sm:grid-cols-4 lg:grid-cols-8">
+          {examples.map((example) => (
+            <TabsTrigger key={example.value} value={example.value} className="rounded-lg font-semibold">
+              {example.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        {examples.map((example) => {
+          const Icon = example.icon
 
           return (
-            <Card key={page.href} className="border-emerald-500/20 bg-black/40">
-              <CardHeader>
-                <div className="flex items-center justify-between gap-3">
-                  <div className="flex items-center gap-3">
-                    <div className="rounded-lg bg-emerald-500/10 p-2 text-emerald-300">
-                      <Icon className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <CardTitle className="text-white">{page.title}</CardTitle>
-                      <CardDescription>{page.description}</CardDescription>
-                    </div>
-                  </div>
-                  <Badge variant="outline" className="border-emerald-500/20 text-emerald-300">
-                    {page.badge}
+            <TabsContent key={example.value} value={example.value}>
+              <Card className="border-border/80 bg-black/40">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Icon className="h-5 w-5" />
+                    {example.title}
+                  </CardTitle>
+                  <CardDescription>{example.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <Badge variant="secondary" className="rounded-full font-mono text-xs">
+                    Status: {example.status}
                   </Badge>
-                </div>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {page.preview}
-                <Button asChild className="w-full">
-                  <Link href={page.href}>
-                    Open Example
-                    <ArrowRight className="ml-2 h-4 w-4" />
-                  </Link>
-                </Button>
-              </CardContent>
-            </Card>
+                  <Terminal commands={example.commands} welcomeMessage={example.welcomeMessage} className="h-48 sm:h-56" />
+                </CardContent>
+              </Card>
+            </TabsContent>
           )
         })}
-      </div>
+      </Tabs>
     </div>
   )
 }

--- a/components/docs/page-nav.tsx
+++ b/components/docs/page-nav.tsx
@@ -24,6 +24,8 @@ const navigationOrder: NavItem[] = [
   { title: "Login Form Example", href: "/docs/examples/login" },
   { title: "Interactive Menu Example", href: "/docs/examples/menu" },
   { title: "ASCII Art Example", href: "/docs/examples/ascii" },
+  { title: "Experimental Overview", href: "/docs/labs" },
+  { title: "WASM Runtime", href: "/docs/labs/wasm-runtime" },
 ]
 
 export function PageNav() {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:web-runtime": "bun run build:web-runtime && bunx --bun http-server . -p 8090 -c-1",
     "lint": "bun --bun  next lint",
     "registry:build": "bun scripts/build-registry.mjs",
+    "registry:check-boundaries": "bun scripts/check-registry-boundaries.mjs",
     "start": "bun --bun next start",
     "test": "bun vitest run",
     "test:watch": "bun vitest",

--- a/packages/web-renderer/dist/index.js
+++ b/packages/web-renderer/dist/index.js
@@ -152,7 +152,13 @@ export class CanvasTerminal {
             return;
         if (event.key === "Backspace") {
             event.preventDefault();
-            this.core.handleKeyInput("\b");
+            this.core.handleKeyInput("\x7f");
+            this.requestRender();
+            return;
+        }
+        if (event.key === "Delete") {
+            event.preventDefault();
+            this.core.handleKeyInput("\x1b[3~");
             this.requestRender();
             return;
         }

--- a/packages/web-renderer/src/index.ts
+++ b/packages/web-renderer/src/index.ts
@@ -208,7 +208,14 @@ export class CanvasTerminal implements TerminalRenderer {
 
     if (event.key === "Backspace") {
       event.preventDefault();
-      this.core.handleKeyInput("\b");
+      this.core.handleKeyInput("\x7f");
+      this.requestRender();
+      return;
+    }
+
+    if (event.key === "Delete") {
+      event.preventDefault();
+      this.core.handleKeyInput("\x1b[3~");
       this.requestRender();
       return;
     }

--- a/scripts/check-registry-boundaries.mjs
+++ b/scripts/check-registry-boundaries.mjs
@@ -1,0 +1,33 @@
+import { readFileSync, readdirSync } from 'fs'
+import { join } from 'path'
+
+const ROOT_DIR = process.cwd()
+const COMPONENT_DIR = join(ROOT_DIR, 'components', 'ui')
+const disallowedPattern = /(?:from\s+['"`][^'"`]*packages\/web-|import\s+['"`][^'"`]*packages\/web-)/
+
+function listTsxFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) return listTsxFiles(path)
+    return path.endsWith('.tsx') || path.endsWith('.ts') ? [path] : []
+  })
+}
+
+const offenders = []
+
+for (const file of listTsxFiles(COMPONENT_DIR)) {
+  const content = readFileSync(file, 'utf8')
+  if (disallowedPattern.test(content)) {
+    offenders.push(file.replace(`${ROOT_DIR}/`, ''))
+  }
+}
+
+if (offenders.length > 0) {
+  console.error('Registry boundary violation: components/ui must not import from packages/web-*')
+  for (const file of offenders) {
+    console.error(`- ${file}`)
+  }
+  process.exit(1)
+}
+
+console.log('Registry boundaries OK: no components/ui imports from packages/web-*')


### PR DESCRIPTION
## Summary
- replace scripted homepage terminal demos with live `WasmTerminal` demo cards to better represent the real browser runtime
- update web renderer keyboard mapping to send explicit Backspace (`\x7f`) and Delete (`\x1b[3~`) sequences into the WASM core
- keep scenario cards visually consistent by rendering welcome copy under the WASM terminal surface

## Why
This aligns the docs homepage with the current architecture direction: keep the shadcn-facing UX stable while showcasing the experimental Zig/WASM runtime through real rendering behavior instead of simulated output.