### PR TITLE
feat: TerminalThemeProvider integration + JSX expression recursion

### DIFF
--- a/app/docs/themes/page.tsx
+++ b/app/docs/themes/page.tsx
@@ -1,22 +1,23 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState } from "react"
 import { Palette, Copy, Check, Sparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Terminal, type OpenTUIContext } from "@/components/ui/terminal"
 import { ThemePicker } from "@/components/theme-picker"
-import { prebuiltThemes, type ThemeConfig } from "@/lib/opentui/themes"
+import { TerminalThemeProvider, useTerminalTheme, prebuiltThemes } from "@/lib/opentui/themes"
 
 export default function ThemesPage() {
-  const [selectedTheme, setSelectedTheme] = useState<ThemeConfig>(prebuiltThemes[0])
-  const [copied, setCopied] = useState(false)
+  return (
+    <TerminalThemeProvider>
+      <ThemesPageContent />
+    </TerminalThemeProvider>
+  )
+}
 
-  const handleThemeChange = useCallback((themeName: string) => {
-    const theme = prebuiltThemes.find((t) => t.name === themeName)
-    if (theme) {
-      setSelectedTheme(theme)
-    }
-  }, [])
+function ThemesPageContent() {
+  const { theme: selectedTheme, setTheme } = useTerminalTheme()
+  const [copied, setCopied] = useState(false)
 
   const configCode = `{
   "theme": "${selectedTheme.name}"
@@ -28,9 +29,8 @@ export default function ThemesPage() {
     setTimeout(() => setCopied(false), 2000)
   }
 
-  // Custom commands for themed terminal demo
-  const themeCommands = {
-    theme: async (args: string[], context: OpenTUIContext) => {
+  const themeCommands: Record<string, (args: string[], context: OpenTUIContext) => Promise<void>> = {
+    theme: async (args, context) => {
       const themeName = args[0]
       if (!themeName) {
         context.addLines([
@@ -43,7 +43,7 @@ export default function ThemesPage() {
       }
       const found = prebuiltThemes.find((t) => t.name === themeName)
       if (found) {
-        setSelectedTheme(found)
+        setTheme(found.name)
         context.addLines([
           `Theme changed to: ${found.displayName}`,
           `Description: ${found.description}`,
@@ -53,7 +53,7 @@ export default function ThemesPage() {
         context.addLines([`Theme "${themeName}" not found. Run 'theme' to see available themes.`])
       }
     },
-    colors: async (args: string[], context: OpenTUIContext) => {
+    colors: async (_args, context) => {
       context.addLines([
         `Current Theme: ${selectedTheme.displayName}`,
         "",
@@ -68,9 +68,8 @@ export default function ThemesPage() {
         `  Warning:    ${selectedTheme.colors.warning}`,
       ])
     },
-    demo: async (args: string[], context: OpenTUIContext) => {
+    demo: async (_args, context) => {
       context.addLines(["Syntax Highlighting Demo:", ""])
-      // Simulate typed code
       await new Promise((r) => setTimeout(r, 100))
       context.addLines([`const theme = "${selectedTheme.name}";`])
       await new Promise((r) => setTimeout(r, 100))
@@ -119,7 +118,7 @@ export default function ThemesPage() {
         </div>
 
         <div className="flex items-center gap-4">
-          <ThemePicker value={selectedTheme.name} onValueChange={handleThemeChange} />
+          <ThemePicker value={selectedTheme.name} onValueChange={setTheme} />
           <div className="flex items-center gap-2">
             {[
               selectedTheme.colors.primary,
@@ -180,9 +179,6 @@ export default function ThemesPage() {
           <div
             style={{
               backgroundColor: selectedTheme.colors.background,
-              ["--terminal-text" as string]: selectedTheme.colors.text,
-              ["--terminal-primary" as string]: selectedTheme.colors.primary,
-              ["--terminal-success" as string]: selectedTheme.colors.success,
             }}
           >
             <Terminal
@@ -195,8 +191,6 @@ export default function ThemesPage() {
               prompt="→"
               className="border-0 rounded-none shadow-none"
               style={{
-                backgroundColor: selectedTheme.colors.background,
-                color: selectedTheme.colors.text,
                 ["--tw-text-opacity" as string]: "1",
               }}
             />
@@ -211,7 +205,7 @@ export default function ThemesPage() {
           {prebuiltThemes.map((theme) => (
             <button
               key={theme.name}
-              onClick={() => setSelectedTheme(theme)}
+              onClick={() => setTheme(theme.name)}
               className={`
                 relative p-4 rounded-lg border-2 transition-all text-left w-full
                 hover:scale-[1.02] hover:shadow-lg

--- a/components/ui/terminal.tsx
+++ b/components/ui/terminal.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import React, { useState, useRef, useCallback, useContext, createContext, useEffect, useLayoutEffect } from "react"
+import React, { useState, useRef, useCallback, useContext, createContext, useEffect, useLayoutEffect, useMemo } from "react"
 import { cn } from "@/lib/utils"
 import type { CommandHandler } from "@/lib/types" // Declare or import CommandHandler
+import { useOptionalTerminalTheme, getThemeCSS } from "@/lib/opentui/themes"
 
 interface TerminalLine {
   id: string
@@ -322,6 +323,20 @@ const createBuiltInCommands = (
   },
 ]
 
+function parseCSSVars(css: string): Record<string, string> {
+  const vars: Record<string, string> = {}
+  for (const line of css.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed || !trimmed.endsWith(";")) continue
+    const colonIdx = trimmed.indexOf(":")
+    if (colonIdx === -1) continue
+    const key = trimmed.slice(0, colonIdx).trim()
+    const value = trimmed.slice(colonIdx + 1, -1).trim()
+    vars[key] = value
+  }
+  return vars
+}
+
 const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
   (
     {
@@ -368,6 +383,18 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
     const velocityRef = useRef<number>(0)
     const isAnimatingRef = useRef<boolean>(false)
     const targetScrollRef = useRef<number>(0)
+
+    const themeCtx = useOptionalTerminalTheme()
+
+    const themeCSSVars = useMemo(() => {
+      if (!themeCtx) return {}
+      return parseCSSVars(getThemeCSS(themeCtx.theme))
+    }, [themeCtx])
+
+    const combinedTheme = useMemo(() => ({
+      ...themeCSSVars,
+      ...theme,
+    }), [themeCSSVars, theme])
 
     const opentuiState = useState<TerminalState>({
       mode: "command",
@@ -1005,7 +1032,7 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
             getVariantStyles(),
             className,
           )}
-          style={{ ...theme, ...props.style } as React.CSSProperties}
+          style={{ ...combinedTheme, ...props.style } as React.CSSProperties}
           onClick={(e) => {
             const target = e.target as HTMLElement
             const isFormInput =

--- a/lib/opentui-codegen/parse-hunk.ts
+++ b/lib/opentui-codegen/parse-hunk.ts
@@ -29,6 +29,43 @@ function extractJsxAttributeValue(attr: any): unknown {
   return `<${initializer.getKindName()}>`
 }
 
+function parseJsxExpressionChildren(expr: any): OpenTUIIrNode[] {
+  const results: OpenTUIIrNode[] = []
+
+  const jsxElements = expr.getDescendantsOfKind(SyntaxKind.JsxElement) as JsxElement[]
+  const selfClosing = expr.getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement) as JsxSelfClosingElement[]
+  const allElements = [...jsxElements, ...selfClosing]
+
+  const topLevel = allElements.filter((el: any) => {
+    let parent = el.getParent()
+    while (parent && !parent.isKind(SyntaxKind.JsxExpression)) {
+      if (parent.isKind(SyntaxKind.JsxElement) || parent.isKind(SyntaxKind.JsxSelfClosingElement)) {
+        return false
+      }
+      parent = parent.getParent()
+      if (!parent) return false
+    }
+    return parent?.isKind(SyntaxKind.JsxExpression)
+  })
+
+  if (topLevel.length > 0) {
+    for (const el of topLevel) {
+      if (el.isKind(SyntaxKind.JsxElement)) {
+        results.push(parseJsxNode(el))
+      } else {
+        results.push(parseJsxSelfClosing(el))
+      }
+    }
+  } else {
+    const text = expr.getText().trim()
+    if (text.length > 0) {
+      results.push({ kind: "text", value: text.length > 80 ? text.slice(0, 80) + "..." : text })
+    }
+  }
+
+  return results
+}
+
 function parseJsxChildren(element: JsxElement): OpenTUIIrNode[] {
   const children: OpenTUIIrNode[] = []
 
@@ -38,10 +75,8 @@ function parseJsxChildren(element: JsxElement): OpenTUIIrNode[] {
     } else if (child.isKind(SyntaxKind.JsxSelfClosingElement)) {
       children.push(parseJsxSelfClosing(child as JsxSelfClosingElement))
     } else if (child.isKind(SyntaxKind.JsxExpression)) {
-      const text = child.getText().trim()
-      if (text.length > 0) {
-        children.push({ kind: "text", value: text.length > 80 ? text.slice(0, 80) + "..." : text })
-      }
+      const nestedResults = parseJsxExpressionChildren(child)
+      children.push(...nestedResults)
     }
   }
 

--- a/lib/opentui/themes.tsx
+++ b/lib/opentui/themes.tsx
@@ -533,6 +533,11 @@ export function useTerminalTheme() {
   return context
 }
 
+export function useOptionalTerminalTheme(): ThemeContextValue | null {
+  const context = useContext(ThemeContext)
+  return context
+}
+
 interface TerminalThemeProviderProps {
   children: ReactNode
   defaultTheme?: string

--- a/test/components/terminal.test.tsx
+++ b/test/components/terminal.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 
 import { Terminal } from '@/components/ui/terminal'
+import { TerminalThemeProvider } from '@/lib/opentui/themes'
 
 describe('Terminal', () => {
   it('shows command completions, supports arrow navigation, and completes with tab', async () => {
@@ -116,5 +117,31 @@ describe('Terminal', () => {
     const errorLine = container.querySelector('.text-terminal-error')
     expect(errorLine).not.toBeNull()
     expect(errorLine).toHaveTextContent(/not found/i)
+  })
+
+  it('applies theme from TerminalThemeProvider context', () => {
+    const { container } = render(
+      <TerminalThemeProvider defaultTheme="tokyo-night">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+    const root = container.firstChild as HTMLElement
+    // Tokyo Night primary color
+    expect(root.style.getPropertyValue('--terminal-primary')).toBe('#7aa2f7')
+  })
+
+  it('explicit theme prop overrides TerminalThemeProvider context', () => {
+    const { container } = render(
+      <TerminalThemeProvider defaultTheme="matrix">
+        <Terminal
+          theme={{
+            '--terminal-primary': '#ff0000',
+          }}
+        />
+      </TerminalThemeProvider>,
+    )
+    const root = container.firstChild as HTMLElement
+    // Context would set #22c55e (matrix primary), but prop should win
+    expect(root.style.getPropertyValue('--terminal-primary')).toBe('#ff0000')
   })
 })

--- a/test/opentui-codegen/__snapshots__/generate-shadcn.test.ts.snap
+++ b/test/opentui-codegen/__snapshots__/generate-shadcn.test.ts.snap
@@ -1,0 +1,272 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`generateShadcnComponent > generates component from box with nested children 1`] = `
+"import type { HunkDiffFileInput } from "hunkdiff/opentui"
+import type { HunkDiffSelection } from "hunkdiff/opentui"
+
+export function NestedBoxes({
+  files,
+  layout = "split",
+  width = 80,
+  theme = "graphite",
+  selection,
+  showLineNumbers = true,
+  showHunkHeaders = true,
+  wrapLines = false,
+  highlight = true,
+  showFileHeaders = true,
+  showFileSeparators = true,
+  horizontalOffset = 0,
+  onSelectionChange,
+}: {
+  files?: HunkDiffFileInput[]
+  layout?: "split" | "stack"
+  width?: number
+  theme?: string
+  selection?: HunkDiffSelection
+  showLineNumbers?: boolean
+  showHunkHeaders?: boolean
+  wrapLines?: boolean
+  highlight?: boolean
+  showFileHeaders?: boolean
+  showFileSeparators?: boolean
+  horizontalOffset?: number
+  onSelectionChange?: (s: HunkDiffSelection) => void
+}) {
+  return (
+    <div className="flex flex-col w-full">
+      <div className="flex flex-col w-full">
+        <span className="font-mono text-sm text-emerald-200">Header</span>
+        <div className="w-full">
+          <span className="font-mono text-sm text-zinc-500">Nested content</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+"
+`;
+
+exports[`generateShadcnComponent > generates component from minimal text-only IR 1`] = `
+"import type { HunkDiffFileInput } from "hunkdiff/opentui"
+import type { HunkDiffSelection } from "hunkdiff/opentui"
+
+export function SimpleView({
+  files,
+  layout = "split",
+  width = 80,
+  theme = "graphite",
+  selection,
+  showLineNumbers = true,
+  showHunkHeaders = true,
+  wrapLines = false,
+  highlight = true,
+  showFileHeaders = true,
+  showFileSeparators = true,
+  horizontalOffset = 0,
+  onSelectionChange,
+}: {
+  files?: HunkDiffFileInput[]
+  layout?: "split" | "stack"
+  width?: number
+  theme?: string
+  selection?: HunkDiffSelection
+  showLineNumbers?: boolean
+  showHunkHeaders?: boolean
+  wrapLines?: boolean
+  highlight?: boolean
+  showFileHeaders?: boolean
+  showFileSeparators?: boolean
+  horizontalOffset?: number
+  onSelectionChange?: (s: HunkDiffSelection) => void
+}) {
+  return (
+    <div className="flex flex-col w-full">
+      <span className="font-mono text-sm text-emerald-200">Hello, World!</span>
+    </div>
+  )
+}
+"
+`;
+
+exports[`generateShadcnComponent > generates component with empty box 1`] = `
+"import type { HunkDiffFileInput } from "hunkdiff/opentui"
+import type { HunkDiffSelection } from "hunkdiff/opentui"
+
+export function EmptyBox({
+  files,
+  layout = "split",
+  width = 80,
+  theme = "graphite",
+  selection,
+  showLineNumbers = true,
+  showHunkHeaders = true,
+  wrapLines = false,
+  highlight = true,
+  showFileHeaders = true,
+  showFileSeparators = true,
+  horizontalOffset = 0,
+  onSelectionChange,
+}: {
+  files?: HunkDiffFileInput[]
+  layout?: "split" | "stack"
+  width?: number
+  theme?: string
+  selection?: HunkDiffSelection
+  showLineNumbers?: boolean
+  showHunkHeaders?: boolean
+  wrapLines?: boolean
+  highlight?: boolean
+  showFileHeaders?: boolean
+  showFileSeparators?: boolean
+  horizontalOffset?: number
+  onSelectionChange?: (s: HunkDiffSelection) => void
+}) {
+  return (
+    <div className="flex flex-col w-full">
+      <div className="flex flex-col" />
+    </div>
+  )
+}
+"
+`;
+
+exports[`generateShadcnComponent > generates component with scrollbox wrapper 1`] = `
+"import type { HunkDiffFileInput } from "hunkdiff/opentui"
+import type { HunkDiffSelection } from "hunkdiff/opentui"
+
+export function ScrollingContent({
+  files,
+  layout = "split",
+  width = 80,
+  theme = "graphite",
+  selection,
+  showLineNumbers = true,
+  showHunkHeaders = true,
+  wrapLines = false,
+  highlight = true,
+  showFileHeaders = true,
+  showFileSeparators = true,
+  horizontalOffset = 0,
+  onSelectionChange,
+}: {
+  files?: HunkDiffFileInput[]
+  layout?: "split" | "stack"
+  width?: number
+  theme?: string
+  selection?: HunkDiffSelection
+  showLineNumbers?: boolean
+  showHunkHeaders?: boolean
+  wrapLines?: boolean
+  highlight?: boolean
+  showFileHeaders?: boolean
+  showFileSeparators?: boolean
+  horizontalOffset?: number
+  onSelectionChange?: (s: HunkDiffSelection) => void
+}) {
+  return (
+    <div className="flex flex-col w-full">
+      <div className="overflow-auto h-full w-full">
+        <div className="flex flex-col">
+          <span className="font-mono text-sm text-emerald-200">Line 1</span>
+          <span className="font-mono text-sm text-emerald-200">Line 2</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+"
+`;
+
+exports[`generateShadcnComponent > generates component with unknown HunkDiffBody node 1`] = `
+"import type { HunkDiffFileInput } from "hunkdiff/opentui"
+import type { HunkDiffSelection } from "hunkdiff/opentui"
+
+export function WithDiffBody({
+  files,
+  layout = "split",
+  width = 80,
+  theme = "graphite",
+  selection,
+  showLineNumbers = true,
+  showHunkHeaders = true,
+  wrapLines = false,
+  highlight = true,
+  showFileHeaders = true,
+  showFileSeparators = true,
+  horizontalOffset = 0,
+  onSelectionChange,
+}: {
+  files?: HunkDiffFileInput[]
+  layout?: "split" | "stack"
+  width?: number
+  theme?: string
+  selection?: HunkDiffSelection
+  showLineNumbers?: boolean
+  showHunkHeaders?: boolean
+  wrapLines?: boolean
+  highlight?: boolean
+  showFileHeaders?: boolean
+  showFileSeparators?: boolean
+  horizontalOffset?: number
+  onSelectionChange?: (s: HunkDiffSelection) => void
+}) {
+  return (
+    <div className="flex flex-col w-full">
+      <div className="flex flex-col w-full font-mono text-xs">
+        <span className="font-mono text-sm text-zinc-500">diff content</span>
+      </div>
+    </div>
+  )
+}
+"
+`;
+
+exports[`generateShadcnComponent > generates full HunkReviewStream program 1`] = `
+"import type { HunkDiffFileInput } from "hunkdiff/opentui"
+import type { HunkDiffSelection } from "hunkdiff/opentui"
+
+export function HunkReviewStream({
+  files,
+  layout = "split",
+  width = 80,
+  theme = "graphite",
+  selection,
+  showLineNumbers = true,
+  showHunkHeaders = true,
+  wrapLines = false,
+  highlight = true,
+  showFileHeaders = true,
+  showFileSeparators = true,
+  horizontalOffset = 0,
+  onSelectionChange,
+}: {
+  files?: HunkDiffFileInput[]
+  layout?: "split" | "stack"
+  width?: number
+  theme?: string
+  selection?: HunkDiffSelection
+  showLineNumbers?: boolean
+  showHunkHeaders?: boolean
+  wrapLines?: boolean
+  highlight?: boolean
+  showFileHeaders?: boolean
+  showFileSeparators?: boolean
+  horizontalOffset?: number
+  onSelectionChange?: (s: HunkDiffSelection) => void
+}) {
+  return (
+    <div className="flex flex-col w-full">
+      {/* HunkReviewStream */}
+      <div className="flex flex-col w-full">
+        <div className="flex flex-col w-full font-mono text-xs">
+          <div className="flex flex-col w-full">
+            <span className="font-mono text-sm text-emerald-200">diff content here</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+"
+`;

--- a/test/opentui-codegen/__snapshots__/parse-hunk.test.ts.snap
+++ b/test/opentui-codegen/__snapshots__/parse-hunk.test.ts.snap
@@ -1,0 +1,383 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`parseHunkFile > falls back to text for expression children without JSX 1`] = `
+{
+  "name": "TextFallback",
+  "nodes": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "kind": "text",
+                  "value": "{name}",
+                },
+              ],
+              "kind": "text",
+              "props": undefined,
+            },
+          ],
+          "kind": "box",
+          "props": undefined,
+        },
+      ],
+      "kind": "unknown",
+      "name": "TextFallback",
+    },
+  ],
+  "source": "TextFallback.tsx",
+}
+`;
+
+exports[`parseHunkFile > handles JSX expression children with nested OpenTUI primitives 1`] = `
+{
+  "name": "FilesList",
+  "nodes": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "kind": "text",
+                      "value": "{file.name}",
+                    },
+                  ],
+                  "kind": "text",
+                  "props": {
+                    "fg": "white",
+                  },
+                },
+              ],
+              "kind": "box",
+              "props": {
+                "key": "<file.id>",
+                "style": true,
+              },
+            },
+          ],
+          "kind": "box",
+          "props": {
+            "style": true,
+          },
+        },
+      ],
+      "kind": "unknown",
+      "name": "FilesList",
+    },
+  ],
+  "source": "FilesList.tsx",
+}
+`;
+
+exports[`parseHunkFile > handles JSX expression with conditional ternary returning JSX 1`] = `
+{
+  "name": "ConditionalView",
+  "nodes": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": undefined,
+                  "kind": "text",
+                  "props": {
+                    "fg": "green",
+                  },
+                },
+              ],
+              "kind": "box",
+              "props": {
+                "style": true,
+              },
+            },
+            {
+              "children": [
+                {
+                  "children": undefined,
+                  "kind": "text",
+                  "props": {
+                    "fg": "muted",
+                  },
+                },
+              ],
+              "kind": "box",
+              "props": undefined,
+            },
+          ],
+          "kind": "box",
+          "props": {
+            "style": true,
+          },
+        },
+      ],
+      "kind": "unknown",
+      "name": "ConditionalView",
+    },
+  ],
+  "source": "ConditionalView.tsx",
+}
+`;
+
+exports[`parseHunkFile > parses HunkFileNav-style pattern with group/file entries 1`] = `
+{
+  "name": "HunkFileNav",
+  "nodes": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "kind": "text",
+                      "value": "{entry.name}",
+                    },
+                  ],
+                  "kind": "text",
+                  "props": {
+                    "fg": "cyan",
+                  },
+                },
+              ],
+              "kind": "box",
+              "props": {
+                "key": "<entry.id>",
+              },
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "kind": "text",
+                      "value": "{entry.name}",
+                    },
+                  ],
+                  "kind": "text",
+                  "props": {
+                    "fg": "white",
+                  },
+                },
+              ],
+              "kind": "box",
+              "props": {
+                "key": "<entry.id>",
+              },
+            },
+          ],
+          "kind": "box",
+          "props": {
+            "style": true,
+          },
+        },
+      ],
+      "kind": "unknown",
+      "name": "HunkFileNav",
+    },
+  ],
+  "source": "HunkFileNav.tsx",
+}
+`;
+
+exports[`parseHunkFile > parses HunkReviewStream-style pattern with map and conditional JSX 1`] = `
+{
+  "name": "HunkReviewStream",
+  "nodes": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "{"\\u2500".repeat(Math.max(1, width - 2))}",
+                        },
+                      ],
+                      "kind": "text",
+                      "props": {
+                        "fg": "border",
+                      },
+                    },
+                  ],
+                  "kind": "box",
+                  "props": {
+                    "style": true,
+                  },
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "{file.path}",
+                        },
+                      ],
+                      "kind": "text",
+                      "props": {
+                        "fg": "white",
+                      },
+                    },
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "{file.additions}",
+                        },
+                      ],
+                      "kind": "text",
+                      "props": {
+                        "fg": "green",
+                      },
+                    },
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "{file.deletions}",
+                        },
+                      ],
+                      "kind": "text",
+                      "props": {
+                        "fg": "red",
+                      },
+                    },
+                  ],
+                  "kind": "box",
+                  "props": {
+                    "style": true,
+                  },
+                },
+              ],
+              "kind": "box",
+              "props": {
+                "key": "<file.id>",
+                "style": true,
+              },
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "kind": "text",
+                      "value": "{"\\u2500".repeat(Math.max(1, width - 2))}",
+                    },
+                  ],
+                  "kind": "text",
+                  "props": {
+                    "fg": "border",
+                  },
+                },
+              ],
+              "kind": "box",
+              "props": {
+                "style": true,
+              },
+            },
+          ],
+          "kind": "box",
+          "props": {
+            "style": true,
+          },
+        },
+      ],
+      "kind": "unknown",
+      "name": "HunkReviewStream",
+    },
+  ],
+  "source": "HunkReviewStream.tsx",
+}
+`;
+
+exports[`parseHunkFile > parses basic box and text elements 1`] = `
+{
+  "name": "SimpleBox",
+  "nodes": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": undefined,
+              "kind": "text",
+              "props": {
+                "fg": "green",
+              },
+            },
+          ],
+          "kind": "box",
+          "props": {
+            "style": true,
+          },
+        },
+      ],
+      "kind": "unknown",
+      "name": "SimpleBox",
+    },
+  ],
+  "source": "SimpleBox.tsx",
+}
+`;
+
+exports[`parseHunkFile > parses self-closing scrollbox 1`] = `
+{
+  "name": "ScrollingView",
+  "nodes": [
+    {
+      "children": [
+        {
+          "kind": "scrollbox",
+          "props": {
+            "focused": false,
+            "height": "100%",
+            "scrollY": true,
+            "width": "100%",
+          },
+        },
+      ],
+      "kind": "unknown",
+      "name": "ScrollingView",
+    },
+  ],
+  "source": "ScrollingView.tsx",
+}
+`;
+
+exports[`parseHunkFile > parses unknown elements as 'unknown' kind 1`] = `
+{
+  "name": "WithCustom",
+  "nodes": [
+    {
+      "children": [
+        {
+          "kind": "unknown",
+          "name": "CustomComponent",
+          "props": {
+            "files": "<files>",
+            "onSelect": true,
+          },
+        },
+      ],
+      "kind": "unknown",
+      "name": "WithCustom",
+    },
+  ],
+  "source": "WithCustom.tsx",
+}
+`;

--- a/test/opentui-codegen/generate-shadcn.test.ts
+++ b/test/opentui-codegen/generate-shadcn.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest"
+import { generateShadcnComponent } from "@/lib/opentui-codegen/generate-shadcn"
+import type { OpenTUIIrProgram } from "@/lib/opentui-codegen/ir"
+
+describe("generateShadcnComponent", () => {
+  it("generates component from minimal text-only IR", () => {
+    const program: OpenTUIIrProgram = {
+      name: "SimpleView",
+      source: "simple.tsx",
+      nodes: [
+        {
+          kind: "text",
+          value: "Hello, World!",
+        },
+      ],
+      notes: [],
+    }
+    expect(generateShadcnComponent(program)).toMatchSnapshot()
+  })
+
+  it("generates component from box with nested children", () => {
+    const program: OpenTUIIrProgram = {
+      name: "NestedBoxes",
+      source: "nested.tsx",
+      nodes: [
+        {
+          kind: "box",
+          props: { style: { flexDirection: "column", width: "100%" } },
+          children: [
+            { kind: "text", value: "Header", props: { fg: "white" } },
+            {
+              kind: "box",
+              props: { style: { width: "100%" } },
+              children: [
+                { kind: "text", value: "Nested content", props: { fg: "muted" } },
+              ],
+            },
+          ],
+        },
+      ],
+      notes: [],
+    }
+    expect(generateShadcnComponent(program)).toMatchSnapshot()
+  })
+
+  it("generates component with scrollbox wrapper", () => {
+    const program: OpenTUIIrProgram = {
+      name: "ScrollingContent",
+      source: "scroll.tsx",
+      nodes: [
+        {
+          kind: "scrollbox",
+          children: [
+            {
+              kind: "box",
+              props: { style: { flexDirection: "column" } },
+              children: [
+                { kind: "text", value: "Line 1" },
+                { kind: "text", value: "Line 2" },
+              ],
+            },
+          ],
+        },
+      ],
+      notes: [],
+    }
+    expect(generateShadcnComponent(program)).toMatchSnapshot()
+  })
+
+  it("generates component with unknown HunkDiffBody node", () => {
+    const program: OpenTUIIrProgram = {
+      name: "WithDiffBody",
+      source: "diff-body.tsx",
+      nodes: [
+        {
+          kind: "unknown",
+          name: "HunkDiffBody",
+          children: [
+            { kind: "text", value: "diff content", props: { fg: "muted" } },
+          ],
+        },
+      ],
+      notes: [],
+    }
+    expect(generateShadcnComponent(program)).toMatchSnapshot()
+  })
+
+  it("generates full HunkReviewStream program", () => {
+    const program: OpenTUIIrProgram = {
+      name: "HunkReviewStream",
+      source: "HunkReviewStream.tsx",
+      nodes: [
+        {
+          kind: "unknown",
+          name: "HunkReviewStream",
+          children: [
+            {
+              kind: "box",
+              props: { style: { width: "100%", flexDirection: "column" } },
+              children: [
+                {
+                  kind: "unknown",
+                  name: "HunkDiffBody",
+                  children: [
+                    {
+                      kind: "box",
+                      props: { style: { flexDirection: "column", width: "100%" } },
+                      children: [
+                        { kind: "text", value: "diff content here" },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      notes: ["Exported function: HunkReviewStream"],
+    }
+    expect(generateShadcnComponent(program)).toMatchSnapshot()
+  })
+
+  it("generates component with empty box", () => {
+    const program: OpenTUIIrProgram = {
+      name: "EmptyBox",
+      source: "empty.tsx",
+      nodes: [
+        {
+          kind: "box",
+          props: { style: { flexDirection: "column" } },
+        },
+      ],
+      notes: [],
+    }
+    expect(generateShadcnComponent(program)).toMatchSnapshot()
+  })
+})

--- a/test/opentui-codegen/parse-hunk.test.ts
+++ b/test/opentui-codegen/parse-hunk.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest"
+import { parseHunkFile } from "@/lib/opentui-codegen/parse-hunk"
+
+function stripNotes(program: ReturnType<typeof parseHunkFile>) {
+  return { name: program.name, source: program.source, nodes: program.nodes }
+}
+
+describe("parseHunkFile", () => {
+  it("parses basic box and text elements", () => {
+    const source = `
+export function SimpleBox() {
+  return (
+    <box style={{ flexDirection: "column", width: "100%" }}>
+      <text fg="green">Hello, World!</text>
+    </box>
+  )
+}`
+    const result = parseHunkFile(source, "SimpleBox.tsx")
+    expect(stripNotes(result)).toMatchSnapshot()
+  })
+
+  it("parses self-closing scrollbox", () => {
+    const source = `
+export function ScrollingView() {
+  return (
+    <scrollbox width="100%" height="100%" scrollY={true} focused={false} />
+  )
+}`
+    const result = parseHunkFile(source, "ScrollingView.tsx")
+    expect(stripNotes(result)).toMatchSnapshot()
+  })
+
+  it("handles JSX expression children with nested OpenTUI primitives", () => {
+    const source = `
+export function FilesList({ files }: { files: { id: string; name: string }[] }) {
+  return (
+    <box style={{ width: "100%", flexDirection: "column" }}>
+      {files.map((file) => (
+        <box key={file.id} style={{ width: "100%" }}>
+          <text fg="white">{file.name}</text>
+        </box>
+      ))}
+    </box>
+  )
+}`
+    const result = parseHunkFile(source, "FilesList.tsx")
+    expect(stripNotes(result)).toMatchSnapshot()
+  })
+
+  it("handles JSX expression with conditional ternary returning JSX", () => {
+    const source = `
+export function ConditionalView({ show }: { show: boolean }) {
+  return (
+    <box style={{ width: "100%" }}>
+      {show ? (
+        <box style={{ flexDirection: "column" }}>
+          <text fg="green">Visible</text>
+        </box>
+      ) : (
+        <box>
+          <text fg="muted">Hidden</text>
+        </box>
+      )}
+    </box>
+  )
+}`
+    const result = parseHunkFile(source, "ConditionalView.tsx")
+    expect(stripNotes(result)).toMatchSnapshot()
+  })
+
+  it("falls back to text for expression children without JSX", () => {
+    const source = `
+export function TextFallback({ name }: { name: string }) {
+  return (
+    <box>
+      <text>{name}</text>
+    </box>
+  )
+}`
+    const result = parseHunkFile(source, "TextFallback.tsx")
+    expect(stripNotes(result)).toMatchSnapshot()
+  })
+
+  it("parses unknown elements as 'unknown' kind", () => {
+    const source = `
+export function WithCustom({ files }: { files: any[] }) {
+  return (
+    <CustomComponent
+      files={files}
+      onSelect={(id: string) => {}}
+    />
+  )
+}`
+    const result = parseHunkFile(source, "WithCustom.tsx")
+    expect(stripNotes(result)).toMatchSnapshot()
+  })
+
+  it("parses HunkReviewStream-style pattern with map and conditional JSX", () => {
+    const source = `
+export function HunkReviewStream({
+  files,
+  width,
+}: {
+  files: { id: string; path: string; additions: number; deletions: number }[]
+  width: number
+}) {
+  return (
+    <box style={{ width: "100%", flexDirection: "column" }}>
+      {files.map((file, index) => (
+        <box key={file.id} style={{ width: "100%", flexDirection: "column" }}>
+          {index > 0 ? (
+            <box style={{ width: "100%" }}>
+              <text fg="border">{"\\u2500".repeat(Math.max(1, width - 2))}</text>
+            </box>
+          ) : null}
+          <box style={{ width: "100%", flexDirection: "column" }}>
+            <text fg="white">{file.path}</text>
+            <text fg="green">+{file.additions}</text>
+            <text fg="red">-{file.deletions}</text>
+          </box>
+        </box>
+      ))}
+    </box>
+  )
+}`
+    const result = parseHunkFile(source, "HunkReviewStream.tsx")
+    expect(stripNotes(result)).toMatchSnapshot()
+  })
+
+  it("parses HunkFileNav-style pattern with group/file entries", () => {
+    const source = `
+export function HunkFileNav({ entries }: { entries: { id: string; kind: string; name: string }[] }) {
+  return (
+    <box style={{ width: "100%", flexDirection: "column" }}>
+      {entries.map((entry) =>
+        entry.kind === "group" ? (
+          <box key={entry.id}>
+            <text fg="cyan">{entry.name}</text>
+          </box>
+        ) : (
+          <box key={entry.id}>
+            <text fg="white">{entry.name}</text>
+          </box>
+        ),
+      )}
+    </box>
+  )
+}`
+    const result = parseHunkFile(source, "HunkFileNav.tsx")
+    expect(stripNotes(result)).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
## What

Wires `TerminalThemeProvider` context into the `<Terminal>` component so themes auto-apply. Expands the ts-morph parser to recurse into JSX `{...}` expression children (e.g., `.map()`, ternaries).

## Theme Context Integration

- **`useOptionalTerminalTheme()`** — non-throwing context accessor exported from `lib/opentui/themes.tsx`
- **`combinedTheme`** in `terminal.tsx` — merges context CSS vars with explicit `theme` prop (prop wins)
- **`parseCSSVars()`** — converts `getThemeCSS()` string to `Record<string, string>` for spread into `style`
- **Themes page** — now wraps in `<TerminalThemeProvider>`, uses `setTheme` from context, removed manual CSS override pass-through (auto now)

## Parser Expansion

- **`parseJsxExpressionChildren()`** — finds top-level JSX elements inside `{...}` expressions (e.g., `{files.map(f => <box>...</box>)}`, `{show ? <A /> : <B />}`)
- Falls back to text dump when no JSX is inside the expression

## New Tests

- **8 parse tests**: basic, self-closing, nested JSX in map, conditional ternary, text fallback, unknown elements, HunkReviewStream pattern, HunkFileNav pattern
- **6 generate tests**: minimal text, nested boxes, scrollbox, unknown nodes, full programs, empty containers

All 39 tests pass, 18 pages build clean.