### PR TITLE
fix: render terminal ascii and table output correctly

### DIFF
--- a/components/ui/terminal.tsx
+++ b/components/ui/terminal.tsx
@@ -4,6 +4,7 @@ import React, { useState, useRef, useCallback, useContext, createContext, useEff
 import { cn } from "@/lib/utils"
 import type { CommandHandler } from "@/lib/types" // Declare or import CommandHandler
 import { useOptionalTerminalTheme, getThemeCSS } from "@/lib/opentui/themes"
+import { renderAsciiBanner, renderTable, sampleTerminalTableData } from "@/lib/opentui/renderers"
 
 interface TerminalLine {
   id: string
@@ -285,40 +286,16 @@ const createBuiltInCommands = (
     handler: (args) => {
       const text = args.join(" ") || "OpenTUI"
       addLine("Generating ASCII art...", "success")
-
-      // Simple ASCII art generator
-      const asciiArt = [
-        "  ___                   _____ _   _ ___ ",
-        " / _ \\ _ __   ___ _ __  |_   _| | | |_ _|",
-        "| | | | '_ \\ / _ \\ '_ \\   | | | | | || | ",
-        "| |_| | |_) |  __/ | | |  | | | |_| || | ",
-        " \\___/| .__/ \\___|_| |_|  |_|  \\___/|___|",
-        "      |_|                               ",
-      ]
-
-      asciiArt.forEach((line) => addLine(line, "success"))
+      renderAsciiBanner(text).forEach((line) => addLine(line, "success"))
     },
   },
   {
     name: "table",
     description: "Display data in table format",
     category: "data",
-    handler: (args) => {
-      const sampleData = [
-        ["Name", "Age", "City"],
-        ["Alice", "25", "New York"],
-        ["Bob", "30", "San Francisco"],
-        ["Charlie", "35", "Chicago"],
-      ]
-
+    handler: () => {
       addLine("Sample Data Table:", "success")
-      sampleData.forEach((row, index) => {
-        const formattedRow = row.map((cell) => cell.padEnd(12)).join(" | ")
-        addLine(index === 0 ? `| ${formattedRow} |` : `| ${formattedRow} |`, "output")
-        if (index === 0) {
-          addLine(`|${"-".repeat(formattedRow.length + 2)}|`, "output")
-        }
-      })
+      renderTable(sampleTerminalTableData).forEach((line) => addLine(line, "output"))
     },
   },
 ]

--- a/lib/opentui/commands.ts
+++ b/lib/opentui/commands.ts
@@ -1,4 +1,5 @@
 import type { TerminalCommand } from "./types"
+import { renderAsciiBanner, renderTable, sampleTerminalTableData } from "./renderers"
 
 // Built-in system commands
 export const createBuiltInCommands = (): TerminalCommand[] => [
@@ -185,25 +186,24 @@ export const createUICommands = (): TerminalCommand[] => [
     },
   },
   {
+    name: "ascii",
+    description: "Generate ASCII art",
+    category: "ui",
+    usage: "ascii [text]",
+    handler: (args, context) => {
+      const text = args.join(" ") || "OpenTUI"
+
+      context.addLine("Generating ASCII art...", "success")
+      renderAsciiBanner(text).forEach((line) => context.addLine(line, "success"))
+    },
+  },
+  {
     name: "table",
     description: "Display data in table format",
     category: "ui",
     handler: (_, context) => {
-      const data = [
-        ["Name", "Role", "Status"],
-        ["Alice", "Developer", "Active"],
-        ["Bob", "Designer", "Active"],
-        ["Charlie", "Manager", "Away"],
-      ]
-
       context.addLine("Sample Data Table:", "success")
-      data.forEach((row, index) => {
-        const formatted = row.map((cell) => cell.padEnd(12)).join(" │ ")
-        context.addLine(`│ ${formatted} │`)
-        if (index === 0) {
-          context.addLine(`├${"─".repeat(formatted.length + 2)}┤`)
-        }
-      })
+      renderTable(sampleTerminalTableData).forEach((line) => context.addLine(line))
     },
   },
 ]

--- a/lib/opentui/renderers.ts
+++ b/lib/opentui/renderers.ts
@@ -1,0 +1,76 @@
+const LETTERS: Record<string, string[]> = {
+  A: ["  #  ", " # # ", "#####", "#   #", "#   #"],
+  B: ["#### ", "#   #", "#### ", "#   #", "#### "],
+  C: [" ####", "#    ", "#    ", "#    ", " ####"],
+  D: ["#### ", "#   #", "#   #", "#   #", "#### "],
+  E: ["#####", "#    ", "#### ", "#    ", "#####"],
+  F: ["#####", "#    ", "#### ", "#    ", "#    "],
+  G: [" ####", "#    ", "#  ##", "#   #", " ####"],
+  H: ["#   #", "#   #", "#####", "#   #", "#   #"],
+  I: ["#####", "  #  ", "  #  ", "  #  ", "#####"],
+  J: ["#####", "   # ", "   # ", "#  # ", " ##  "],
+  K: ["#   #", "#  # ", "###  ", "#  # ", "#   #"],
+  L: ["#    ", "#    ", "#    ", "#    ", "#####"],
+  M: ["#   #", "## ##", "# # #", "#   #", "#   #"],
+  N: ["#   #", "##  #", "# # #", "#  ##", "#   #"],
+  O: [" ### ", "#   #", "#   #", "#   #", " ### "],
+  P: ["#### ", "#   #", "#### ", "#    ", "#    "],
+  Q: [" ### ", "#   #", "#   #", "#  ##", " ####"],
+  R: ["#### ", "#   #", "#### ", "#  # ", "#   #"],
+  S: [" ####", "#    ", " ### ", "    #", "#### "],
+  T: ["#####", "  #  ", "  #  ", "  #  ", "  #  "],
+  U: ["#   #", "#   #", "#   #", "#   #", " ### "],
+  V: ["#   #", "#   #", "#   #", " # # ", "  #  "],
+  W: ["#   #", "#   #", "# # #", "## ##", "#   #"],
+  X: ["#   #", " # # ", "  #  ", " # # ", "#   #"],
+  Y: ["#   #", " # # ", "  #  ", "  #  ", "  #  "],
+  Z: ["#####", "   # ", "  #  ", " #   ", "#####"],
+  "0": [" ### ", "#  ##", "# # #", "##  #", " ### "],
+  "1": ["  #  ", " ##  ", "  #  ", "  #  ", " ### "],
+  "2": [" ### ", "#   #", "   # ", "  #  ", "#####"],
+  "3": ["#### ", "    #", " ### ", "    #", "#### "],
+  "4": ["#   #", "#   #", "#####", "    #", "    #"],
+  "5": ["#####", "#    ", "#### ", "    #", "#### "],
+  "6": [" ### ", "#    ", "#### ", "#   #", " ### "],
+  "7": ["#####", "   # ", "  #  ", " #   ", "#    "],
+  "8": [" ### ", "#   #", " ### ", "#   #", " ### "],
+  "9": [" ### ", "#   #", " ####", "    #", " ### "],
+  " ": ["   ", "   ", "   ", "   ", "   "],
+}
+
+const FALLBACK = ["#####", "#   #", "  ## ", "     ", "  #  "]
+
+export const sampleTerminalTableData = [
+  ["Name", "Age", "City"],
+  ["Alice", "25", "New York"],
+  ["Bob", "30", "San Francisco"],
+  ["Charlie", "35", "Chicago"],
+]
+
+export function renderAsciiBanner(text = "OpenTUI"): string[] {
+  const normalized = text.trim() || "OpenTUI"
+  const glyphs = [...normalized.toUpperCase()].map((char) => LETTERS[char] ?? FALLBACK)
+
+  return Array.from({ length: 5 }, (_, row) => glyphs.map((glyph) => glyph[row]).join(" ").trimEnd())
+}
+
+export function renderTable(rows: string[][]): string[] {
+  if (rows.length === 0) return []
+
+  const columnCount = Math.max(...rows.map((row) => row.length))
+  const widths = Array.from({ length: columnCount }, (_, column) =>
+    Math.max(...rows.map((row) => String(row[column] ?? "").length)),
+  )
+
+  const border = (left: string, join: string, right: string) =>
+    `${left}${widths.map((width) => "─".repeat(width + 2)).join(join)}${right}`
+
+  const rowLine = (row: string[]) =>
+    `│ ${widths.map((width, column) => String(row[column] ?? "").padEnd(width)).join(" │ ")} │`
+
+  const lines = [border("┌", "┬", "┐"), rowLine(rows[0]), border("├", "┼", "┤")]
+  rows.slice(1).forEach((row) => lines.push(rowLine(row)))
+  lines.push(border("└", "┴", "┘"))
+
+  return lines
+}

--- a/test/components/terminal.test.tsx
+++ b/test/components/terminal.test.tsx
@@ -119,6 +119,39 @@ describe('Terminal', () => {
     expect(errorLine).toHaveTextContent(/not found/i)
   })
 
+  it('renders ascii output from the provided words', async () => {
+    const user = userEvent.setup()
+
+    render(<Terminal />)
+
+    const input = screen.getByPlaceholderText('Type a command...')
+    await user.click(input)
+    await user.type(input, 'ascii hello world')
+    await user.keyboard('{Enter}')
+
+    expect(
+      screen.getByText((_, element) =>
+        element?.textContent === '#   # ##### #     #      ###      #   #  ###  ####  #     ####',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('renders table output with aligned borders and intersections', async () => {
+    const user = userEvent.setup()
+
+    render(<Terminal />)
+
+    const input = screen.getByPlaceholderText('Type a command...')
+    await user.click(input)
+    await user.type(input, 'table')
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByText('┌─────────┬─────┬───────────────┐')).toBeInTheDocument()
+    expect(screen.getByText('├─────────┼─────┼───────────────┤')).toBeInTheDocument()
+    expect(screen.getByText((_, element) => element?.textContent === '│ Bob     │ 30  │ San Francisco │')).toBeInTheDocument()
+    expect(screen.getByText('└─────────┴─────┴───────────────┘')).toBeInTheDocument()
+  })
+
   it('applies theme from TerminalThemeProvider context', () => {
     const { container } = render(
       <TerminalThemeProvider defaultTheme="tokyo-night">

--- a/test/unit/opentui-commands.test.ts
+++ b/test/unit/opentui-commands.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createUICommands } from '@/lib/opentui/commands'
+import type { OpenTUIRuntimeContext, TerminalLine } from '@/lib/opentui/types'
+
+function createContext() {
+  const lines: Array<{ content: string; type?: TerminalLine['type'] }> = []
+  const context = {
+    state: {
+      mode: { type: 'command' },
+      lines: [],
+      commandHistory: [],
+      historyIndex: -1,
+      isProcessing: false,
+      formData: {},
+      menuSelection: 0,
+      theme: {
+        prompt: '$',
+        colors: {
+          background: '',
+          foreground: '',
+          input: '',
+          output: '',
+          error: '',
+          success: '',
+          system: '',
+          accent: '',
+        },
+        font: { family: '', size: '' },
+      },
+    },
+    addLine: (content: string, type?: TerminalLine['type']) => lines.push({ content, type }),
+    clearLines: vi.fn(),
+    updateLastLine: vi.fn(),
+    showUI: vi.fn(),
+    hideUI: vi.fn(),
+    setMode: vi.fn(),
+    updateFormData: vi.fn(),
+    getFormData: vi.fn(() => ({})),
+    clearFormData: vi.fn(),
+    registerCommand: vi.fn(),
+    unregisterCommand: vi.fn(),
+    getCommands: vi.fn(() => []),
+  } satisfies OpenTUIRuntimeContext
+
+  return { context, lines }
+}
+
+describe('OpenTUI command helpers', () => {
+  it('table command emits full table outline with San Francisco intact', () => {
+    const { context, lines } = createContext()
+    const table = createUICommands().find((command) => command.name === 'table')
+
+    table?.handler([], context)
+
+    const output = lines.map((line) => line.content)
+    expect(output[1]).toMatch(/^┌.*┐$/)
+    expect(output[3]).toMatch(/^├.*┤$/)
+    expect(output.at(-1)).toMatch(/^└.*┘$/)
+    expect(output).toContain('│ Bob     │ 30  │ San Francisco │')
+  })
+
+  it('ascii command changes output for input text', () => {
+    const helloRun = createContext()
+    const defaultRun = createContext()
+    const ascii = createUICommands().find((command) => command.name === 'ascii')
+
+    ascii?.handler(['hello'], helloRun.context)
+    ascii?.handler([], defaultRun.context)
+
+    expect(helloRun.lines.slice(1).map((line) => line.content)).not.toEqual(
+      defaultRun.lines.slice(1).map((line) => line.content),
+    )
+    expect(helloRun.lines.map((line) => line.content)).toContain('#   # ##### #     #      ###')
+  })
+})

--- a/test/unit/terminal-renderers.test.ts
+++ b/test/unit/terminal-renderers.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderAsciiBanner, renderTable, sampleTerminalTableData } from '@/lib/opentui/renderers'
+
+describe('terminal renderers', () => {
+  it('renders table borders and keeps San Francisco in one row', () => {
+    const lines = renderTable(sampleTerminalTableData)
+
+    expect(lines[0]).toMatch(/^┌.*┐$/)
+    expect(lines[2]).toMatch(/^├.*┤$/)
+    expect(lines.at(-1)).toMatch(/^└.*┘$/)
+    expect(lines).toContain('│ Bob     │ 30  │ San Francisco │')
+  })
+
+  it('renders ascii output from the provided input text', () => {
+    const hello = renderAsciiBanner('hello')
+    const opentui = renderAsciiBanner('OpenTUI')
+
+    expect(hello).not.toEqual(opentui)
+    expect(hello).toContain('#   # ##### #     #      ###')
+    expect(opentui.join('\n')).toContain(' ###  ####')
+  })
+})


### PR DESCRIPTION
## Summary
- Add shared terminal render helpers for ASCII banners and outlined sample tables
- Wire both built-in terminal command paths to the shared helpers
- Fix `ascii [text]` so it renders the provided words instead of a constant OpenTUI banner
- Fix `table` output to include top, header, and bottom borders with aligned column intersections

## Verification
- `bun vitest run test/components/terminal.test.tsx` — 12 tests passed
- `bun vitest run` — 53 tests passed across 13 files
- `bun --bun next build` — compiled successfully, 18 pages generated