### PR TITLE
fix: align getThemeCSS variable names with globals.css

### DIFF
--- a/app/docs/themes/page.tsx
+++ b/app/docs/themes/page.tsx
@@ -6,6 +6,16 @@ import { Button } from "@/components/ui/button"
 import { Terminal, type OpenTUIContext } from "@/components/ui/terminal"
 import { ThemePicker } from "@/components/theme-picker"
 import { TerminalThemeProvider, useTerminalTheme, prebuiltThemes } from "@/lib/opentui/themes"
+import type { CommandHandler } from "@/lib/types"
+
+type ThemeMenuItem = {
+  label: string
+  value: string
+}
+
+function isThemeMenuItem(item: unknown): item is ThemeMenuItem {
+  return Boolean(item && typeof item === "object" && "value" in item && typeof (item as ThemeMenuItem).value === "string")
+}
 
 export default function ThemesPage() {
   return (
@@ -20,7 +30,8 @@ function ThemesPageContent() {
   const [copied, setCopied] = useState(false)
 
   const configCode = `{
-  "theme": "${selectedTheme.name}"
+  "theme": "${selectedTheme.name}",
+  "fontFamily": "${selectedTheme.fontFamily ?? "default mono"}"
 }`
 
   const handleCopy = () => {
@@ -29,65 +40,121 @@ function ThemesPageContent() {
     setTimeout(() => setCopied(false), 2000)
   }
 
-  const themeCommands: Record<string, (args: string[], context: OpenTUIContext) => Promise<void>> = {
-    theme: async (args, context) => {
-      const themeName = args[0]
-      if (!themeName) {
+  const themeCommands: Record<string, CommandHandler> = {
+    theme: {
+      name: "theme",
+      description: "Preview and select a terminal theme",
+      category: "ui",
+      handler: async (args, context?: OpenTUIContext) => {
+        if (!context) return
+        const themeName = args[0]
+        if (!themeName) {
+          const originalThemeName = selectedTheme.name
+          const items: ThemeMenuItem[] = prebuiltThemes.map((theme) => ({
+            label: `${theme.displayName.padEnd(18)} ${theme.variant.padEnd(5)} ${theme.description}`,
+            value: theme.name,
+          }))
+          const selectedIndex = Math.max(
+            0,
+            prebuiltThemes.findIndex((theme) => theme.name === selectedTheme.name),
+          )
+
+          context.addLines([
+            "Choose a theme:",
+            "Use ↑/↓ to preview. Press Enter to save, Esc to cancel.",
+          ])
+          context.setState((prev) => ({
+            ...prev,
+            mode: "ui",
+            menuSelection: selectedIndex,
+            activeComponent: {
+              id: `theme-menu-${Date.now()}`,
+              type: "menu",
+              active: true,
+              props: {
+                items,
+                onPreview: (item: unknown) => {
+                  if (isThemeMenuItem(item)) setTheme(item.value)
+                },
+                onSelect: (item: unknown) => {
+                  if (!isThemeMenuItem(item)) return
+                  const found = prebuiltThemes.find((theme) => theme.name === item.value)
+                  if (!found) return
+                  setTheme(found.name)
+                  context.addLines([
+                    `Theme saved: ${found.displayName}`,
+                    `Description: ${found.description}`,
+                    `Variant: ${found.variant}`,
+                  ])
+                },
+                onCancel: () => {
+                  setTheme(originalThemeName)
+                  context.addLine("Theme change cancelled", "error")
+                },
+              },
+            },
+          }))
+          return
+        }
+        const found = prebuiltThemes.find((t) => t.name === themeName)
+        if (found) {
+          setTheme(found.name)
+          context.addLines([
+            `Theme changed to: ${found.displayName}`,
+            `Description: ${found.description}`,
+            `Variant: ${found.variant}`,
+          ])
+        } else {
+          context.addLines([`Theme "${themeName}" not found. Run 'theme' to choose from the menu.`])
+        }
+      },
+    },
+    colors: {
+      name: "colors",
+      description: "Show the selected theme color palette",
+      handler: async (_args, context?: OpenTUIContext) => {
+        if (!context) return
         context.addLines([
-          "Usage: theme <name>",
+          `Current Theme: ${selectedTheme.displayName}`,
           "",
-          "Available themes:",
-          ...prebuiltThemes.map((t) => `  ${t.name.padEnd(15)} - ${t.description}`),
+          "Color Palette:",
+          `  Primary:    ${selectedTheme.colors.primary}`,
+          `  Secondary:  ${selectedTheme.colors.secondary}`,
+          `  Accent:     ${selectedTheme.colors.accent}`,
+          `  Background: ${selectedTheme.colors.background}`,
+          `  Text:       ${selectedTheme.colors.text}`,
+          `  Font:       ${selectedTheme.fontFamily ?? "default mono"}`,
+          `  Success:    ${selectedTheme.colors.success}`,
+          `  Error:      ${selectedTheme.colors.error}`,
+          `  Warning:    ${selectedTheme.colors.warning}`,
         ])
-        return
-      }
-      const found = prebuiltThemes.find((t) => t.name === themeName)
-      if (found) {
-        setTheme(found.name)
+      },
+    },
+    demo: {
+      name: "demo",
+      description: "Show syntax preview output",
+      handler: async (_args, context?: OpenTUIContext) => {
+        if (!context) return
+        context.addLines(["Syntax Highlighting Demo:", ""])
+        await new Promise((r) => setTimeout(r, 100))
+        context.addLines([`const theme = "${selectedTheme.name}";`])
+        await new Promise((r) => setTimeout(r, 100))
+        context.addLines([`function applyTheme(name: string) {`])
+        await new Promise((r) => setTimeout(r, 100))
+        context.addLines([`  console.log("Applying:", name);`])
+        await new Promise((r) => setTimeout(r, 100))
+        context.addLines([`  return { success: true };`])
+        await new Promise((r) => setTimeout(r, 100))
+        context.addLines([`}`])
+        await new Promise((r) => setTimeout(r, 200))
         context.addLines([
-          `Theme changed to: ${found.displayName}`,
-          `Description: ${found.description}`,
-          `Variant: ${found.variant}`,
+          "",
+          "Status Messages:",
+          "✓ Theme loaded successfully",
+          "ℹ Using " + selectedTheme.variant + " mode",
+          "⚠ " + prebuiltThemes.length + " themes available",
         ])
-      } else {
-        context.addLines([`Theme "${themeName}" not found. Run 'theme' to see available themes.`])
-      }
-    },
-    colors: async (_args, context) => {
-      context.addLines([
-        `Current Theme: ${selectedTheme.displayName}`,
-        "",
-        "Color Palette:",
-        `  Primary:    ${selectedTheme.colors.primary}`,
-        `  Secondary:  ${selectedTheme.colors.secondary}`,
-        `  Accent:     ${selectedTheme.colors.accent}`,
-        `  Background: ${selectedTheme.colors.background}`,
-        `  Text:       ${selectedTheme.colors.text}`,
-        `  Success:    ${selectedTheme.colors.success}`,
-        `  Error:      ${selectedTheme.colors.error}`,
-        `  Warning:    ${selectedTheme.colors.warning}`,
-      ])
-    },
-    demo: async (_args, context) => {
-      context.addLines(["Syntax Highlighting Demo:", ""])
-      await new Promise((r) => setTimeout(r, 100))
-      context.addLines([`const theme = "${selectedTheme.name}";`])
-      await new Promise((r) => setTimeout(r, 100))
-      context.addLines([`function applyTheme(name: string) {`])
-      await new Promise((r) => setTimeout(r, 100))
-      context.addLines([`  console.log("Applying:", name);`])
-      await new Promise((r) => setTimeout(r, 100))
-      context.addLines([`  return { success: true };`])
-      await new Promise((r) => setTimeout(r, 100))
-      context.addLines([`}`])
-      await new Promise((r) => setTimeout(r, 200))
-      context.addLines([
-        "",
-        "Status Messages:",
-        "✓ Theme loaded successfully",
-        "ℹ Using " + selectedTheme.variant + " mode",
-        "⚠ " + prebuiltThemes.length + " themes available",
-      ])
+      },
     },
   }
 
@@ -168,9 +235,14 @@ function ThemesPageContent() {
                 <div className="w-3 h-3 rounded-full" style={{ backgroundColor: selectedTheme.colors.warning }} />
                 <div className="w-3 h-3 rounded-full" style={{ backgroundColor: selectedTheme.colors.success }} />
               </div>
-              <span className="text-sm font-mono" style={{ color: selectedTheme.colors.textMuted }}>
-                {selectedTheme.displayName} — OpenTUI Terminal
-              </span>
+                <span className="text-sm font-mono" style={{ color: selectedTheme.colors.textMuted }}>
+                  {selectedTheme.displayName} — OpenTUI Terminal
+                </span>
+                {selectedTheme.fontFamily && (
+                  <span className="text-xs" style={{ color: selectedTheme.colors.textMuted }}>
+                    {selectedTheme.fontFamily.split(",")[0].replaceAll('"', "")}
+                  </span>
+                )}
             </div>
             <Palette className="w-4 h-4" style={{ color: selectedTheme.colors.primary }} />
           </div>
@@ -182,7 +254,6 @@ function ThemesPageContent() {
             }}
           >
             <Terminal
-              key={selectedTheme.name}
               welcomeMessage={[
                 `Welcome to OpenTUI — ${selectedTheme.displayName} Theme`,
                 `Type 'theme' to list themes, 'colors' to see palette, or 'demo' for syntax preview.`,
@@ -212,7 +283,6 @@ function ThemesPageContent() {
               style={{
                 backgroundColor: theme.colors.background,
                 borderColor: theme.name === selectedTheme.name ? theme.colors.primary : theme.colors.border,
-                ringColor: theme.colors.primary,
               }}
             >
               {theme.name === selectedTheme.name && (
@@ -349,7 +419,8 @@ const myTheme: ThemeConfig = {
     accent: '${selectedTheme.colors.accent}',
     background: '${selectedTheme.colors.background}',
     // ... define all colors
-  }
+  },
+  fontFamily: '${selectedTheme.fontFamily ?? "\"SF Mono\", \"Fira Code\", ui-monospace, monospace"}'
 }
 
 // Use with TerminalThemeProvider

--- a/app/docs/themes/page.tsx
+++ b/app/docs/themes/page.tsx
@@ -182,6 +182,7 @@ function ThemesPageContent() {
             }}
           >
             <Terminal
+              key={selectedTheme.name}
               welcomeMessage={[
                 `Welcome to OpenTUI — ${selectedTheme.displayName} Theme`,
                 `Type 'theme' to list themes, 'colors' to see palette, or 'demo' for syntax preview.`,
@@ -190,9 +191,6 @@ function ThemesPageContent() {
               commands={themeCommands}
               prompt="→"
               className="border-0 rounded-none shadow-none"
-              style={{
-                ["--tw-text-opacity" as string]: "1",
-              }}
             />
           </div>
         </div>

--- a/components/ui/terminal.tsx
+++ b/components/ui/terminal.tsx
@@ -41,6 +41,8 @@ interface TerminalUIComponent {
   active: boolean
 }
 
+type TerminalLineInput = string | { content: string; type?: TerminalLine["type"] }
+
 interface TerminalState {
   mode: "command" | "ui" | "form"
   activeComponent?: TerminalUIComponent
@@ -61,7 +63,7 @@ interface CommandCompletion {
     removeUIComponent: (id: string) => void
     updateFormData: (key: string, value: any) => void
     addLine: (content: string, type?: TerminalLine["type"]) => void
-    addLines: (lines: Array<{ content: string; type?: TerminalLine["type"] }>) => void
+    addLines: (lines: TerminalLineInput[]) => void
     clearLines: () => void
     updateLastLine: (content: string, type?: TerminalLine["type"]) => void
   }
@@ -314,6 +316,19 @@ function parseCSSVars(css: string): Record<string, string> {
   return vars
 }
 
+function getMenuItemLabel(item: unknown): string {
+  if (typeof item === "string") return item
+  if (item && typeof item === "object") {
+    const maybeLabel = (item as { label?: unknown; name?: unknown; value?: unknown }).label
+    if (typeof maybeLabel === "string") return maybeLabel
+    const maybeName = (item as { name?: unknown }).name
+    if (typeof maybeName === "string") return maybeName
+    const maybeValue = (item as { value?: unknown }).value
+    if (typeof maybeValue === "string") return maybeValue
+  }
+  return String(item)
+}
+
 const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
   (
     {
@@ -341,6 +356,20 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
         timestamp: new Date(),
       })),
     )
+    const welcomeMessageSignature = welcomeMessage.join("\u0000")
+
+    useEffect(() => {
+      setLines((prev) => {
+        const nonWelcomeLines = prev.filter((line) => !line.id.startsWith("welcome-"))
+        const nextWelcomeLines = welcomeMessage.map((msg, i) => ({
+          id: `welcome-${i}`,
+          type: "output" as const,
+          content: msg,
+          timestamp: new Date(),
+        }))
+        return [...nextWelcomeLines, ...nonWelcomeLines].slice(-maxLines)
+      })
+    }, [welcomeMessageSignature, maxLines])
 
     const [currentInput, setCurrentInput] = useState("")
     const [isProcessing, setIsProcessing] = useState(false)
@@ -445,7 +474,13 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
       },
       addLine,
       addLines: (lines) => {
-        lines.forEach((l) => addLine(l.content, l.type))
+        lines.forEach((line) => {
+          if (typeof line === "string") {
+            addLine(line)
+          } else {
+            addLine(line.content, line.type)
+          }
+        })
       },
       clearLines,
       updateLastLine,
@@ -576,26 +611,30 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (opentuiState[0].mode === "ui" && opentuiState[0].activeComponent?.type === "menu") {
+        const activeComponent = opentuiState[0].activeComponent
+        const menuItems = activeComponent.props.items || []
         if (e.key === "ArrowUp") {
           e.preventDefault()
-          opentuiState[1]((prev) => ({
-            ...prev,
-            menuSelection: Math.max(0, prev.menuSelection - 1),
-          }))
+          const nextSelection = Math.max(0, opentuiState[0].menuSelection - 1)
+          activeComponent.props.onPreview?.(menuItems[nextSelection], nextSelection)
+          opentuiState[1]((prev) => ({ ...prev, menuSelection: nextSelection }))
           return
         } else if (e.key === "ArrowDown") {
           e.preventDefault()
-          const maxItems = opentuiState[0].activeComponent?.props.items?.length || 0
-          opentuiState[1]((prev) => ({
-            ...prev,
-            menuSelection: Math.min(maxItems - 1, prev.menuSelection + 1),
-          }))
+          const maxItems = menuItems.length || 0
+          const nextSelection = Math.min(maxItems - 1, opentuiState[0].menuSelection + 1)
+          activeComponent.props.onPreview?.(menuItems[nextSelection], nextSelection)
+          opentuiState[1]((prev) => ({ ...prev, menuSelection: nextSelection }))
           return
         } else if (e.key === "Enter") {
           e.preventDefault()
-          const selectedItem = opentuiState[0].activeComponent?.props.items?.[opentuiState[0].menuSelection]
+          const selectedItem = menuItems[opentuiState[0].menuSelection]
           if (selectedItem) {
-            addLine(`Selected: ${selectedItem}`, "success")
+            if (activeComponent.props.onSelect) {
+              activeComponent.props.onSelect(selectedItem, opentuiState[0].menuSelection)
+            } else {
+              addLine(`Selected: ${getMenuItemLabel(selectedItem)}`, "success")
+            }
             opentuiState[1]((prev) => ({ ...prev, mode: "command", activeComponent: undefined }))
           }
           return
@@ -604,6 +643,9 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
 
       if (e.key === "Escape" && opentuiState[0].mode !== "command") {
         e.preventDefault()
+        if (opentuiState[0].activeComponent?.type === "menu") {
+          opentuiState[0].activeComponent.props.onCancel?.()
+        }
         opentuiState[1]((prev) => ({ ...prev, mode: "command", activeComponent: undefined, formData: {} }))
         setCurrentFormFieldIndex(0)
         addLine("Exited UI mode", "success")
@@ -748,7 +790,7 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
           return (
             <div className="border border-terminal-border rounded p-2 mb-2 bg-terminal-bg/50">
               <div className="text-terminal-primary text-xs mb-2">MENU (Use ↑↓ arrows, ENTER to select)</div>
-              {props.items?.map((item: string, index: number) => (
+              {props.items?.map((item: unknown, index: number) => (
                 <div
                   key={index}
                   className={cn(
@@ -757,7 +799,7 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
                   )}
                 >
                   {index === opentuiState[0].menuSelection ? "► " : "  "}
-                  {item}
+                  {getMenuItemLabel(item)}
                 </div>
               ))}
             </div>
@@ -1010,7 +1052,13 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
             getVariantStyles(),
             className,
           )}
-          style={{ ...combinedTheme, ...style } as React.CSSProperties}
+          style={
+            {
+              fontFamily: "var(--terminal-font-family, var(--font-mono))",
+              ...combinedTheme,
+              ...style,
+            } as React.CSSProperties
+          }
           onClick={(e) => {
             const target = e.target as HTMLElement
             const isFormInput =

--- a/components/ui/terminal.tsx
+++ b/components/ui/terminal.tsx
@@ -328,6 +328,7 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
       autoScroll = true,
       smoothScroll = true,
       theme,
+      style,
       ...props
     },
     ref,
@@ -1009,7 +1010,7 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
             getVariantStyles(),
             className,
           )}
-          style={{ ...combinedTheme, ...props.style } as React.CSSProperties}
+          style={{ ...combinedTheme, ...style } as React.CSSProperties}
           onClick={(e) => {
             const target = e.target as HTMLElement
             const isFormInput =
@@ -1072,7 +1073,7 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
                     line.type === "input" && "text-terminal-text font-semibold",
                     line.type === "error" && "text-terminal-error",
                     line.type === "success" && "text-terminal-success",
-                    line.type === "output" && "text-terminal-primary",
+                    line.type === "output" && "text-terminal-text",
                   )}
                 >
                   {line.content}

--- a/lib/opentui/themes.tsx
+++ b/lib/opentui/themes.tsx
@@ -716,17 +716,17 @@ export function getThemeCSS(theme: ThemeConfig): string {
     --terminal-primary: ${theme.colors.primary};
     --terminal-secondary: ${theme.colors.secondary};
     --terminal-accent: ${theme.colors.accent};
-    --terminal-background: ${theme.colors.background};
+    --terminal-bg: ${theme.colors.background};
     --terminal-background-panel: ${theme.colors.backgroundPanel};
     --terminal-background-element: ${theme.colors.backgroundElement};
     --terminal-text: ${theme.colors.text};
-    --terminal-text-muted: ${theme.colors.textMuted};
+    --terminal-muted: ${theme.colors.textMuted};
     --terminal-border: ${theme.colors.border};
     --terminal-success: ${theme.colors.success};
     --terminal-error: ${theme.colors.error};
     --terminal-warning: ${theme.colors.warning};
     --terminal-info: ${theme.colors.info};
     --terminal-cursor: ${theme.colors.cursor};
-    --terminal-selection: ${theme.colors.selection};
+    --terminal-highlight-bg: ${theme.colors.selection};
   `
 }

--- a/lib/opentui/themes.tsx
+++ b/lib/opentui/themes.tsx
@@ -47,6 +47,7 @@ export interface ThemeConfig {
   displayName: string
   description: string
   variant: "dark" | "light"
+  fontFamily?: string
   colors: ThemeColors
 }
 
@@ -598,6 +599,76 @@ const catppuccinLatteTheme: ThemeConfig = {
   },
 }
 
+const caiDarkTheme: ThemeConfig = {
+  name: "cai-dark",
+  displayName: "CAI Dark",
+  description: "Canadian AI dark brand theme with neutral ink and maple signal accents",
+  variant: "dark",
+  fontFamily: '"SF Mono", "Fira Code", ui-monospace, monospace',
+  colors: {
+    primary: "#e63030",
+    secondary: "#c8401a",
+    accent: "#f0f0f0",
+    background: "#171717",
+    backgroundPanel: "#1f1f1f",
+    backgroundElement: "#2e2e2e",
+    text: "#f0f0f0",
+    textMuted: "#a8a8a8",
+    textInverse: "#141414",
+    border: "#3d3d3d",
+    success: "#f0f0f0",
+    error: "#e63030",
+    warning: "#c8401a",
+    info: "#b0b0b0",
+    syntaxKeyword: "#e63030",
+    syntaxString: "#f0f0f0",
+    syntaxNumber: "#c8401a",
+    syntaxFunction: "#ffffff",
+    syntaxVariable: "#e8e8e8",
+    syntaxComment: "#a8a8a8",
+    syntaxOperator: "#e63030",
+    syntaxPunctuation: "#b0b0b0",
+    promptSymbol: "#e63030",
+    cursor: "#e63030",
+    selection: "#e6303033",
+  },
+}
+
+const caiLightTheme: ThemeConfig = {
+  name: "cai-light",
+  displayName: "CAI Light",
+  description: "Canadian AI light brand theme with snow surfaces and ink typography",
+  variant: "light",
+  fontFamily: '"SF Mono", "Fira Code", ui-monospace, monospace',
+  colors: {
+    primary: "#e63030",
+    secondary: "#c8401a",
+    accent: "#141414",
+    background: "#f7f7f7",
+    backgroundPanel: "#ffffff",
+    backgroundElement: "#e8e8e8",
+    text: "#141414",
+    textMuted: "#717171",
+    textInverse: "#ffffff",
+    border: "#b0b0b0",
+    success: "#3a3a3a",
+    error: "#e63030",
+    warning: "#c8401a",
+    info: "#717171",
+    syntaxKeyword: "#e63030",
+    syntaxString: "#3a3a3a",
+    syntaxNumber: "#c8401a",
+    syntaxFunction: "#141414",
+    syntaxVariable: "#3a3a3a",
+    syntaxComment: "#717171",
+    syntaxOperator: "#e63030",
+    syntaxPunctuation: "#3a3a3a",
+    promptSymbol: "#e63030",
+    cursor: "#141414",
+    selection: "#e6303033",
+  },
+}
+
 export const prebuiltThemes: ThemeConfig[] = [
   matrixTheme,
   tokyoNightTheme,
@@ -615,6 +686,8 @@ export const prebuiltThemes: ThemeConfig[] = [
   solarizedLightTheme,
   githubLightTheme,
   catppuccinLatteTheme,
+  caiDarkTheme,
+  caiLightTheme,
 ]
 
 // ============================================================================
@@ -728,5 +801,6 @@ export function getThemeCSS(theme: ThemeConfig): string {
     --terminal-info: ${theme.colors.info};
     --terminal-cursor: ${theme.colors.cursor};
     --terminal-highlight-bg: ${theme.colors.selection};
+    ${theme.fontFamily ? `--terminal-font-family: ${theme.fontFamily};` : ""}
   `
 }

--- a/test/components/terminal.test.tsx
+++ b/test/components/terminal.test.tsx
@@ -78,7 +78,11 @@ describe('Terminal', () => {
     const { container } = render(
       <Terminal
         commands={{
-          test: async () => {},
+          test: {
+            name: 'test',
+            description: 'Test command',
+            handler: async () => {},
+          },
         }}
       />,
     )
@@ -176,5 +180,83 @@ describe('Terminal', () => {
     const root = container.firstChild as HTMLElement
     // Context would set #22c55e (matrix primary), but prop should win
     expect(root.style.getPropertyValue('--terminal-primary')).toBe('#ff0000')
+  })
+
+  it('supports addLines with string entries from custom commands', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Terminal
+        commands={{
+          theme: {
+            name: 'theme',
+            description: 'List themes',
+            handler: (_args, context) => {
+              context?.addLines?.(['Choose a theme:', 'Use arrows to preview.'])
+            },
+          },
+        }}
+      />,
+    )
+
+    const input = screen.getByPlaceholderText('Type a command...')
+    await user.click(input)
+    await user.type(input, 'theme')
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByText('Choose a theme:')).toBeInTheDocument()
+    expect(screen.getByText('Use arrows to preview.')).toBeInTheDocument()
+    expect(screen.queryByText(/Error executing theme/)).not.toBeInTheDocument()
+  })
+
+  it('previews menu items on arrow keys and only selects on enter', async () => {
+    const user = userEvent.setup()
+    const previews: string[] = []
+    const selections: string[] = []
+
+    render(
+      <Terminal
+        commands={{
+          theme: {
+            name: 'theme',
+            description: 'Choose a theme',
+            handler: (_args, context) => {
+              context?.setState?.((prev: any) => ({
+                ...prev,
+                mode: 'ui',
+                menuSelection: 0,
+                activeComponent: {
+                  id: 'theme-menu-test',
+                  type: 'menu',
+                  active: true,
+                  props: {
+                    items: [
+                      { label: 'Matrix', value: 'matrix' },
+                      { label: 'Tokyo Night', value: 'tokyo-night' },
+                    ],
+                    onPreview: (item: { value: string }) => previews.push(item.value),
+                    onSelect: (item: { value: string }) => selections.push(item.value),
+                  },
+                },
+              }))
+            },
+          },
+        }}
+      />,
+    )
+
+    const input = screen.getByPlaceholderText('Type a command...')
+    await user.click(input)
+    await user.type(input, 'theme')
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByText('Tokyo Night')).toBeInTheDocument()
+
+    await user.keyboard('{ArrowDown}')
+    expect(previews).toEqual(['tokyo-night'])
+    expect(selections).toEqual([])
+
+    await user.keyboard('{Enter}')
+    expect(selections).toEqual(['tokyo-night'])
   })
 })

--- a/test/components/test-theme-vars.test.tsx
+++ b/test/components/test-theme-vars.test.tsx
@@ -1,0 +1,131 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Terminal } from '@/components/ui/terminal'
+import { TerminalThemeProvider, getThemeCSS, prebuiltThemes } from '@/lib/opentui/themes'
+
+describe('getThemeCSS variable names', () => {
+  const tokyoNight = prebuiltThemes.find(t => t.name === 'tokyo-night')!
+
+  it('emits --terminal-bg (not --terminal-background)', () => {
+    const css = getThemeCSS(tokyoNight)
+    expect(css).toMatch(/--terminal-bg:\s*#[0-9a-f]+;/)
+    expect(css).not.toContain('--terminal-background:')
+  })
+
+  it('emits --terminal-muted (not --terminal-text-muted)', () => {
+    const css = getThemeCSS(tokyoNight)
+    expect(css).toMatch(/--terminal-muted:\s*#[0-9a-f]+;/)
+    expect(css).not.toContain('--terminal-text-muted:')
+  })
+
+  it('emits --terminal-highlight-bg (not --terminal-selection)', () => {
+    const css = getThemeCSS(tokyoNight)
+    expect(css).toMatch(/--terminal-highlight-bg:\s*#[0-9a-f]+;/)
+    expect(css).not.toContain('--terminal-selection:')
+  })
+
+  it('emits all required CSS variables', () => {
+    const css = getThemeCSS(tokyoNight)
+    const required = [
+      '--terminal-primary', '--terminal-secondary', '--terminal-accent',
+      '--terminal-bg', '--terminal-background-panel', '--terminal-background-element',
+      '--terminal-text', '--terminal-muted', '--terminal-border',
+      '--terminal-success', '--terminal-error', '--terminal-warning', '--terminal-info',
+      '--terminal-cursor', '--terminal-highlight-bg',
+    ]
+    for (const v of required) {
+      expect(css).toContain(v)
+    }
+  })
+})
+
+describe('Terminal inline theme styles', () => {
+  it('applies --terminal-bg from context as inline style', () => {
+    const { container } = render(
+      <TerminalThemeProvider defaultTheme="tokyo-night">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+    const root = container.firstChild as HTMLElement
+    const style = root.getAttribute('style') || ''
+    expect(style).toMatch(/--terminal-bg:\s*#[0-9a-f]+;/)
+    expect(style).not.toContain('--terminal-background:')
+  })
+
+  it('applies --terminal-muted from context as inline style', () => {
+    const { container } = render(
+      <TerminalThemeProvider defaultTheme="tokyo-night">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+    const root = container.firstChild as HTMLElement
+    const style = root.getAttribute('style') || ''
+    expect(style).toMatch(/--terminal-muted:\s*#[0-9a-f]+;/)
+    expect(style).not.toContain('--terminal-text-muted:')
+  })
+
+  it('applies --terminal-highlight-bg from context as inline style', () => {
+    const { container } = render(
+      <TerminalThemeProvider defaultTheme="tokyo-night">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+    const root = container.firstChild as HTMLElement
+    const style = root.getAttribute('style') || ''
+    expect(style).toMatch(/--terminal-highlight-bg:\s*#[0-9a-f]+;/)
+    expect(style).not.toContain('--terminal-selection:')
+  })
+
+  it('applies all theme CSS vars as inline style on root element', () => {
+    const { container } = render(
+      <TerminalThemeProvider defaultTheme="tokyo-night">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+    const root = container.firstChild as HTMLElement
+    const style = root.getAttribute('style') || ''
+    const required = [
+      '--terminal-primary', '--terminal-bg', '--terminal-text',
+      '--terminal-muted', '--terminal-border', '--terminal-highlight-bg',
+    ]
+    for (const v of required) {
+      expect(style).toContain(v)
+    }
+  })
+})
+
+describe('Theme change updates inline styles', () => {
+  it('renders different CSS vars for matrix vs tokyo-night', () => {
+    const { container: matrixContainer } = render(
+      <TerminalThemeProvider defaultTheme="matrix">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+    const { container: tokyoContainer } = render(
+      <TerminalThemeProvider defaultTheme="tokyo-night">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+
+    const matrixRoot = matrixContainer.firstChild as HTMLElement
+    const tokyoRoot = tokyoContainer.firstChild as HTMLElement
+
+    const matrixBg = matrixRoot.style.getPropertyValue('--terminal-bg')
+    const tokyoBg = tokyoRoot.style.getPropertyValue('--terminal-bg')
+    expect(matrixBg).not.toBe(tokyoBg)
+    expect(matrixBg).toBe('#0a0a0a')
+    expect(tokyoBg).toBe('#1a1b26')
+  })
+
+  it('preserves old variable names as absent from inline style', () => {
+    const { container } = render(
+      <TerminalThemeProvider defaultTheme="tokyo-night">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+    const root = container.firstChild as HTMLElement
+    expect(root.style.getPropertyValue('--terminal-background')).toBe('')
+    expect(root.style.getPropertyValue('--terminal-text-muted')).toBe('')
+    expect(root.style.getPropertyValue('--terminal-selection')).toBe('')
+  })
+})

--- a/test/components/test-theme-vars.test.tsx
+++ b/test/components/test-theme-vars.test.tsx
@@ -1,4 +1,5 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import type { CSSProperties } from 'react'
 import { describe, expect, it } from 'vitest'
 import { Terminal } from '@/components/ui/terminal'
 import { TerminalThemeProvider, getThemeCSS, prebuiltThemes } from '@/lib/opentui/themes'
@@ -91,6 +92,32 @@ describe('Terminal inline theme styles', () => {
     for (const v of required) {
       expect(style).toContain(v)
     }
+  })
+
+  it('preserves theme CSS vars when user style prop is provided', () => {
+    const { container } = render(
+      <TerminalThemeProvider defaultTheme="catppuccin">
+        <Terminal style={{ '--tw-text-opacity': '1' } as CSSProperties} />
+      </TerminalThemeProvider>,
+    )
+    const root = container.firstChild as HTMLElement
+
+    expect(root.style.getPropertyValue('--terminal-bg')).toBe('#1e1e2e')
+    expect(root.style.getPropertyValue('--terminal-text')).toBe('#cdd6f4')
+    expect(root.style.getPropertyValue('--terminal-primary')).toBe('#cba6f7')
+    expect(root.style.getPropertyValue('--tw-text-opacity')).toBe('1')
+  })
+
+  it('renders output lines with terminal text color, not primary accent color', () => {
+    render(
+      <TerminalThemeProvider defaultTheme="catppuccin">
+        <Terminal welcomeMessage={['Catppuccin preview text']} />
+      </TerminalThemeProvider>,
+    )
+
+    const line = screen.getByText('Catppuccin preview text')
+    expect(line.className).toContain('text-terminal-text')
+    expect(line.className).not.toContain('text-terminal-primary')
   })
 })
 

--- a/test/components/test-theme-vars.test.tsx
+++ b/test/components/test-theme-vars.test.tsx
@@ -38,6 +38,22 @@ describe('getThemeCSS variable names', () => {
       expect(css).toContain(v)
     }
   })
+
+  it('emits optional terminal font family variable', () => {
+    const caiDark = prebuiltThemes.find(t => t.name === 'cai-dark')!
+    const css = getThemeCSS(caiDark)
+    expect(css).toContain('--terminal-font-family: "SF Mono", "Fira Code", ui-monospace, monospace;')
+  })
+
+  it('includes Canadian AI dark and light themes', () => {
+    const caiDark = prebuiltThemes.find(t => t.name === 'cai-dark')!
+    const caiLight = prebuiltThemes.find(t => t.name === 'cai-light')!
+
+    expect(caiDark.colors.background).toBe('#171717')
+    expect(caiDark.colors.primary).toBe('#e63030')
+    expect(caiLight.colors.background).toBe('#f7f7f7')
+    expect(caiLight.colors.text).toBe('#141414')
+  })
 })
 
 describe('Terminal inline theme styles', () => {
@@ -106,6 +122,18 @@ describe('Terminal inline theme styles', () => {
     expect(root.style.getPropertyValue('--terminal-text')).toBe('#cdd6f4')
     expect(root.style.getPropertyValue('--terminal-primary')).toBe('#cba6f7')
     expect(root.style.getPropertyValue('--tw-text-opacity')).toBe('1')
+  })
+
+  it('applies theme font family as an inline CSS variable', () => {
+    const { container } = render(
+      <TerminalThemeProvider defaultTheme="cai-dark">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+    const root = container.firstChild as HTMLElement
+
+    expect(root.style.getPropertyValue('--terminal-font-family')).toBe('"SF Mono", "Fira Code", ui-monospace, monospace')
+    expect(root.style.fontFamily).toBe('var(--terminal-font-family, var(--font-mono))')
   })
 
   it('renders output lines with terminal text color, not primary accent color', () => {


### PR DESCRIPTION
## Problem

`getThemeCSS()` emitted `--terminal-background`, `--terminal-text-muted`, and `--terminal-selection`, but Tailwind/CSS expects `--terminal-bg`, `--terminal-muted`, and `--terminal-highlight-bg`. This mismatch meant theme changes only affected text/border/cursor, not background, muted text, or highlight/selection colors.

## Fix

Changed the 3 mismatched CSS variable names in `getThemeCSS()` to match the `globals.css` definitions. Theme config field names (`colors.background`, `colors.textMuted`, `colors.selection`) are unchanged.

## Tests

Added `test/components/test-theme-vars.test.tsx` with 10 test cases:
- Verifies `getThemeCSS()` emits correct variable names and rejects old names
- Verifies inline styles on rendered `<Terminal>` element contain correct names
- Verifies theme changes produce different CSS var values
- Verifies old variable names are absent from inline styles

## Verification

- `bun vitest run test/components/test-theme-vars.test.tsx test/components/terminal.test.tsx`: 22/22 passed