### PR TITLE
feat: native theme fallback, in-terminal theme modal, agent primitives

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,11 @@ import { MatrixRain } from "@/components/matrix-rain"
 import { OpenTUIRuntimeStatusCard } from "@/components/opentui/runtime-status-card"
 import { Terminal } from "@/components/ui/terminal"
 import { TerminalThemeProvider, prebuiltThemes, useTerminalTheme, type ThemeConfig } from "@/lib/opentui/themes"
+import { TerminalMessage } from "@/components/ui/terminal-message"
+import { TerminalThinkingIndicator } from "@/components/ui/terminal-thinking-indicator"
+import { TerminalStreamText } from "@/components/ui/terminal-stream-text"
+import { TerminalSessionContent } from "@/components/ui/terminal-session-content"
+import { TerminalEditBlock } from "@/components/ui/terminal-edit-block"
 
 const homePreviewThemeNames = ["matrix", "tokyo-night", "catppuccin", "cai-dark", "cai-light"]
 
@@ -164,6 +169,74 @@ function AnimatedThemeSelectorDemoContent() {
         className="h-[320px] rounded-none border-0 shadow-none"
         prompt="→"
       />
+    </div>
+  )
+}
+
+const agentCode = `export function PrimaryButton({ children, className }: ButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex items-center justify-center rounded-md",
+        "px-4 py-2 bg-[var(--terminal-white)]",
+        "text-[var(--terminal-bg)]",
+        "transition-[opacity,transform]",
+        "duration-150 ease-out",
+        "hover:opacity-90 active:scale-[0.98]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}`
+
+function AgentSessionDemo() {
+  const [demoStarted, setDemoStarted] = useState(false)
+
+  if (!demoStarted) {
+    return (
+      <div className="lg:col-span-2 space-y-4 rounded-2xl border border-primary/20 bg-black/50 p-5">
+        <div>
+          <h3 className="text-lg font-semibold text-foreground">Agent session</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Streaming transcript with thinking indicator, stream text, and edit block in a terminal-native layout.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDemoStarted(true)}
+          className="rounded-lg border border-primary/30 bg-primary/10 px-4 py-2 text-sm font-mono text-primary hover:bg-primary/20 transition-colors"
+        >
+          Start demo session
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="lg:col-span-2 space-y-4 rounded-2xl border border-primary/20 bg-black/50 p-5 font-mono">
+      <div className="flex items-center gap-2 px-2 py-1 border-b border-terminal-border/30 text-xs text-terminal-muted">
+        <span className="text-terminal-primary font-semibold">agent session</span>
+      </div>
+      <TerminalSessionContent autoScroll streaming>
+        <TerminalMessage>/improve-the-ui</TerminalMessage>
+        <TerminalThinkingIndicator label="Thinking" />
+        <TerminalStreamText speed={60} mode="fade">
+          I&apos;ll improve the primary button hover — easing the opacity transition and adding a motion-safe press scale.
+        </TerminalStreamText>
+        <TerminalEditBlock
+          file="components/ui/button.tsx"
+          startLine={12}
+          highlightLines={[19, 20, 21]}
+          code={agentCode}
+        />
+        <TerminalStreamText speed={60} mode="fade">
+          Done — hover now eases to 90% opacity with a subtle press-in effect. Want me to apply the same pass to the secondary and ghost variants?
+        </TerminalStreamText>
+      </TerminalSessionContent>
     </div>
   )
 }
@@ -555,6 +628,9 @@ export default function Home() {
                 />
               </div>
             </div>
+          </div>
+          <div className="mt-8 grid lg:grid-cols-2 gap-8">
+            <AgentSessionDemo />
           </div>
         </section>
 

--- a/components/ui/terminal-edit-block.tsx
+++ b/components/ui/terminal-edit-block.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface EditBlockRemovedLine {
+  lineNumber: number
+  content: string
+}
+
+interface TerminalEditBlockProps {
+  file: string
+  startLine?: number
+  highlightLines?: number[]
+  removed?: EditBlockRemovedLine[]
+  code?: string
+  defaultExpanded?: boolean
+  className?: string
+}
+
+function TerminalEditBlock({
+  file,
+  startLine = 1,
+  highlightLines = [],
+  removed = [],
+  code = "",
+  defaultExpanded = true,
+  className,
+}: TerminalEditBlockProps) {
+  const [expanded, setExpanded] = React.useState(defaultExpanded)
+
+  const codeLines = React.useMemo(() => code.split("\n"), [code])
+  const removedSet = React.useMemo(
+    () => new Set(removed.map((r) => r.lineNumber)),
+    [removed]
+  )
+
+  const addedCount = React.useMemo(
+    () => codeLines.filter((_, i) => {
+      const lineNum = startLine + i
+      return !removedSet.has(lineNum) && highlightLines.includes(lineNum)
+    }).length,
+    [codeLines, startLine, removedSet, highlightLines]
+  )
+
+  const removedCount = removed.length
+
+  return (
+    <div className={cn("rounded border border-terminal-border overflow-hidden font-mono", className)}>
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center justify-between w-full px-3 py-1.5 bg-terminal-highlight-bg/30 hover:bg-terminal-highlight-bg/50 transition-colors text-left cursor-pointer"
+      >
+        <div className="flex items-center gap-2 text-xs">
+          <span className={cn(
+            "transition-transform duration-200",
+            expanded && "rotate-90"
+          )}>
+            &#9654;
+          </span>
+          <span className="text-terminal-primary font-medium">{file}</span>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          {addedCount > 0 && (
+            <span className="text-terminal-success">+{addedCount}</span>
+          )}
+          {removedCount > 0 && (
+            <span className="text-terminal-error">-{removedCount}</span>
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-terminal-border">
+          {codeLines.map((line, i) => {
+            const lineNum = startLine + i
+            const isHighlighted = highlightLines.includes(lineNum)
+            const isRemoved = removedSet.has(lineNum)
+
+            return (
+              <div
+                key={i}
+                className={cn(
+                  "flex px-2 py-0.5",
+                  isHighlighted && !isRemoved && "border-l-2 border-terminal-success bg-terminal-success/10",
+                  isRemoved && "border-l-2 border-terminal-error bg-terminal-error/10 line-through text-terminal-muted"
+                )}
+              >
+                <span className="text-terminal-muted text-xs w-8 text-right pr-2 select-none shrink-0">
+                  {lineNum}
+                </span>
+                <span className="text-terminal-text text-xs whitespace-pre">
+                  {line}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export { TerminalEditBlock }

--- a/components/ui/terminal-message.tsx
+++ b/components/ui/terminal-message.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface TerminalMessageProps {
+  prompt?: string
+  children: React.ReactNode
+  className?: string
+}
+
+function TerminalMessage({ prompt = ">", children, className }: TerminalMessageProps) {
+  return (
+    <div className={cn("flex items-start gap-2 px-2 py-1", className)}>
+      <span className="text-terminal-primary font-bold shrink-0">{prompt}</span>
+      <span className="text-terminal-text">{children}</span>
+    </div>
+  )
+}
+
+export { TerminalMessage }

--- a/components/ui/terminal-session-content.tsx
+++ b/components/ui/terminal-session-content.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface TerminalSessionContentProps {
+  children: React.ReactNode
+  streaming?: boolean
+  autoScroll?: boolean
+  resetKey?: string
+  className?: string
+}
+
+function TerminalSessionContent({
+  children,
+  streaming = false,
+  autoScroll = false,
+  resetKey = "",
+  className,
+}: TerminalSessionContentProps) {
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+
+  const elements = React.useMemo(() => {
+    return React.Children.toArray(children).filter(
+      (child) => React.isValidElement(child)
+    )
+  }, [children])
+
+  const [visibleCount, setVisibleCount] = React.useState(streaming ? 0 : elements.length)
+  const STAGGER_MS = 450
+
+  React.useEffect(() => {
+    setVisibleCount(streaming ? 0 : elements.length)
+  }, [resetKey, streaming, elements.length])
+
+  React.useEffect(() => {
+    if (!streaming) {
+      setVisibleCount(elements.length)
+      return
+    }
+
+    if (visibleCount >= elements.length) return
+
+    const timer = setInterval(() => {
+      setVisibleCount((prev) => {
+        const next = prev + 1
+        if (next >= elements.length) {
+          clearInterval(timer)
+        }
+        return next
+      })
+    }, STAGGER_MS)
+
+    return () => clearInterval(timer)
+  }, [streaming, elements.length, visibleCount])
+
+  React.useEffect(() => {
+    if (autoScroll && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [visibleCount, autoScroll])
+
+  return (
+    <div
+      ref={scrollRef}
+      className={cn(autoScroll && "overflow-y-auto", className)}
+    >
+      {elements.map((child, i) => {
+        if (i >= visibleCount) return null
+        return (
+          <div
+            key={i}
+            className="animate-in fade-in duration-300 fill-mode-backwards"
+            style={{ animationDelay: `${i * 50}ms` }}
+          >
+            {child}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export { TerminalSessionContent }

--- a/components/ui/terminal-stream-text.tsx
+++ b/components/ui/terminal-stream-text.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface TerminalStreamTextProps {
+  children: string
+  mode?: "type" | "fade"
+  speed?: number
+  enabled?: boolean
+  onComplete?: () => void
+  className?: string
+}
+
+function TerminalStreamText({
+  children,
+  mode = "type",
+  speed = 26,
+  enabled = true,
+  onComplete,
+  className,
+}: TerminalStreamTextProps) {
+  const [revealedCount, setRevealedCount] = React.useState(0)
+  const intervalRef = React.useRef<ReturnType<typeof setInterval> | null>(null)
+  const completedRef = React.useRef(false)
+
+  const words = React.useMemo(() => children.split(/(\s+)/), [children])
+
+  const delayPerWord = Math.max(20, Math.min(500, Math.round((101 - speed) * 5)))
+
+  React.useEffect(() => {
+    setRevealedCount(0)
+    completedRef.current = false
+  }, [children])
+
+  React.useEffect(() => {
+    if (!enabled || completedRef.current) return
+
+    if (revealedCount >= words.length) {
+      if (!completedRef.current) {
+        completedRef.current = true
+        onComplete?.()
+      }
+      return
+    }
+
+    intervalRef.current = setInterval(() => {
+      setRevealedCount((prev) => {
+        const next = prev + 1
+        if (next >= words.length) {
+          if (intervalRef.current) clearInterval(intervalRef.current)
+          intervalRef.current = null
+          setTimeout(() => {
+            completedRef.current = true
+            onComplete?.()
+          }, 0)
+        }
+        return next
+      })
+    }, delayPerWord)
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [enabled, words.length, delayPerWord, onComplete, revealedCount])
+
+  return (
+    <span className={cn(className)}>
+      {words.map((word, i) => {
+        if (i >= revealedCount) return null
+        if (mode === "fade") {
+          return (
+            <span
+              key={i}
+              className="inline animate-in fade-in duration-300 fill-mode-backwards"
+              style={{ animationDelay: "0ms" }}
+            >
+              {word}
+            </span>
+          )
+        }
+        return <span key={i}>{word}</span>
+      })}
+      {revealedCount < words.length && (
+        <span className="inline-block w-2 h-4 bg-terminal-cursor animate-blink ml-0.5 align-text-bottom" />
+      )}
+    </span>
+  )
+}
+
+function estimateStreamDurationMs(
+  text: string,
+  options?: { speed?: number; mode?: string }
+): number {
+  const speed = options?.speed ?? 26
+  const delayPerWord = Math.max(20, Math.min(500, Math.round((101 - speed) * 5)))
+  const wordCount = text.split(/\s+/).length
+  return wordCount * delayPerWord
+}
+
+export { TerminalStreamText, estimateStreamDurationMs }

--- a/components/ui/terminal-theme-selector.tsx
+++ b/components/ui/terminal-theme-selector.tsx
@@ -1,0 +1,256 @@
+"use client"
+
+import { useState, useEffect, useRef, useMemo, useCallback, useLayoutEffect } from "react"
+import { Search, Check, Sun, Moon } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { ThemeConfig } from "@/lib/opentui/themes"
+
+export interface TerminalThemeSelectorProps {
+  open: boolean
+  themes: ThemeConfig[]
+  currentThemeName: string
+  onSelect: (themeName: string) => void
+  onPreview?: (themeName: string) => void
+  onCancel: () => void
+}
+
+type FilterTab = "all" | "dark" | "light"
+
+export function TerminalThemeSelector({
+  open,
+  themes,
+  currentThemeName,
+  onSelect,
+  onPreview,
+  onCancel,
+}: TerminalThemeSelectorProps) {
+  const [query, setQuery] = useState("")
+  const [filterTab, setFilterTab] = useState<FilterTab>("all")
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const searchRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
+
+  const filtered = useMemo(() => {
+    let result = themes
+    if (filterTab === "dark") {
+      result = result.filter((t) => t.variant === "dark")
+    } else if (filterTab === "light") {
+      result = result.filter((t) => t.variant === "light")
+    }
+    if (query.trim()) {
+      const q = query.toLowerCase().trim()
+      result = result.filter(
+        (t) =>
+          t.name.toLowerCase().includes(q) ||
+          t.displayName.toLowerCase().includes(q) ||
+          t.description.toLowerCase().includes(q) ||
+          t.variant.toLowerCase().includes(q) ||
+          (t.fontFamily && t.fontFamily.toLowerCase().includes(q)),
+      )
+    }
+    return result
+  }, [themes, filterTab, query])
+
+  const currentIdx = useMemo(
+    () => themes.findIndex((t) => t.name === currentThemeName),
+    [themes, currentThemeName],
+  )
+
+  useEffect(() => {
+    if (open) {
+      setQuery("")
+      setFilterTab("all")
+      const idx = filtered.findIndex((t) => t.name === currentThemeName)
+      setSelectedIndex(idx >= 0 ? idx : 0)
+      setTimeout(() => searchRef.current?.focus(), 50)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const idx = filtered.findIndex((t) => t.name === currentThemeName)
+    setSelectedIndex(idx >= 0 ? idx : 0)
+  }, [filterTab, query, filtered, currentThemeName, open])
+
+  useEffect(() => {
+    const el = itemRefs.current.get(selectedIndex)
+    if (el) {
+      el.scrollIntoView({ block: "nearest" })
+    }
+  }, [selectedIndex])
+
+  useLayoutEffect(() => {
+    if (!open) return
+    const theme = filtered[selectedIndex]
+    if (theme) onPreview?.(theme.name)
+  }, [selectedIndex, filtered, open, onPreview])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const isSearchFocused = document.activeElement === searchRef.current
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault()
+          setSelectedIndex((prev) => Math.min(prev + 1, filtered.length - 1))
+          break
+        case "ArrowUp":
+          e.preventDefault()
+          setSelectedIndex((prev) => Math.max(prev - 1, 0))
+          break
+        case "Enter":
+          e.preventDefault()
+          if (filtered[selectedIndex]) {
+            onSelect(filtered[selectedIndex].name)
+          }
+          break
+        case "Escape":
+          e.preventDefault()
+          onCancel()
+          break
+      }
+    },
+    [filtered, selectedIndex, onSelect, onCancel, onPreview],
+  )
+
+  if (!open) return null
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center sm:p-4"
+      onKeyDown={handleKeyDown}
+    >
+      {/* backdrop */}
+      <div className="absolute inset-0 bg-terminal-bg/95 backdrop-blur-sm" />
+
+      {/* mobile bottom sheet */}
+      <div
+        className={cn(
+          "relative flex flex-col",
+          "sm:max-w-[560px] sm:w-full sm:max-h-[80vh] sm:rounded-lg sm:border sm:border-terminal-border sm:bg-terminal-bg",
+          "fixed sm:static bottom-0 left-0 right-0 max-h-[85%] rounded-t-xl border-t border-terminal-border bg-terminal-bg sm:border-t",
+        )}
+      >
+        {/* header: search */}
+        <div className="relative flex-shrink-0 border-b border-terminal-border">
+          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-terminal-muted">
+            <Search className="h-4 w-4" />
+          </div>
+          <input
+            ref={searchRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search themes..."
+            className="w-full bg-transparent py-3 pl-10 pr-4 text-sm text-terminal-text placeholder:text-terminal-muted outline-none"
+            onKeyDown={(e) => {
+              if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+                e.preventDefault()
+              }
+            }}
+          />
+        </div>
+
+        {/* filter tabs */}
+        <div className="flex flex-shrink-0 gap-1 border-b border-terminal-border px-2 py-2">
+          {(["all", "dark", "light"] as FilterTab[]).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setFilterTab(tab)}
+              className={cn(
+                "flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors",
+                filterTab === tab
+                  ? "bg-terminal-primary/20 text-terminal-primary"
+                  : "text-terminal-muted hover:text-terminal-text hover:bg-terminal-highlight-bg",
+              )}
+            >
+              {tab === "all" ? null : tab === "dark" ? (
+                <Moon className="h-3 w-3" />
+              ) : (
+                <Sun className="h-3 w-3" />
+              )}
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        {/* theme list */}
+        <div ref={listRef} className="flex-1 overflow-y-auto py-1">
+          {filtered.length === 0 && (
+            <div className="px-4 py-8 text-center text-sm text-terminal-muted">
+              No themes found
+            </div>
+          )}
+          {filtered.map((theme, idx) => {
+            const isSelected = theme.name === currentThemeName
+            const isHighlighted = idx === selectedIndex
+            return (
+              <div
+                key={theme.name}
+                ref={(el) => {
+                  if (el) itemRefs.current.set(idx, el)
+                  else itemRefs.current.delete(idx)
+                }}
+                onClick={() => onSelect(theme.name)}
+                onMouseEnter={() => {
+                  setSelectedIndex(idx)
+                  onPreview?.(theme.name)
+                }}
+                className={cn(
+                  "flex cursor-pointer items-start gap-3 px-4 py-2.5 transition-colors",
+                  isHighlighted && "bg-terminal-highlight-bg",
+                )}
+              >
+                {/* color swatches */}
+                <div className="flex flex-shrink-0 items-center gap-1 pt-0.5">
+                  <span
+                    className="block h-4 w-4 rounded-full border border-terminal-border"
+                    style={{ backgroundColor: theme.colors.primary }}
+                  />
+                  <span
+                    className="block h-4 w-4 rounded-full border border-terminal-border"
+                    style={{ backgroundColor: theme.colors.secondary }}
+                  />
+                  <span
+                    className="block h-4 w-4 rounded-full border border-terminal-border"
+                    style={{ backgroundColor: theme.colors.accent }}
+                  />
+                </div>
+
+                {/* info */}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-medium text-terminal-text">
+                      {theme.displayName}
+                    </span>
+                    <span
+                      className={cn(
+                        "flex-shrink-0 rounded-full px-1.5 py-px text-[10px] font-medium uppercase leading-tight",
+                        theme.variant === "dark"
+                          ? "bg-terminal-text text-terminal-bg"
+                          : "bg-terminal-muted text-terminal-bg",
+                      )}
+                    >
+                      {theme.variant}
+                    </span>
+                    {isSelected && (
+                      <Check className="ml-auto h-4 w-4 flex-shrink-0 text-terminal-primary" />
+                    )}
+                  </div>
+                  <p className="mt-0.5 truncate text-xs text-terminal-muted">
+                    {theme.description}
+                  </p>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        {/* footer */}
+        <div className="flex-shrink-0 border-t border-terminal-border px-4 py-2 text-center text-xs text-terminal-muted">
+          ↑↓ Navigate · Enter Save · Esc Cancel
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/ui/terminal-thinking-indicator.tsx
+++ b/components/ui/terminal-thinking-indicator.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const DOT_COUNT = 9
+
+const DOT_POSITIONS = [
+  [0, 0], [1, 0], [2, 0],
+  [0, 1], [1, 1], [2, 1],
+  [0, 2], [1, 2], [2, 2],
+]
+
+function buildSpinKeyframes(): string {
+  // Define which dots are lit at each step (0-7), creating a circular pattern
+  const steps: number[][] = [
+    [4],
+    [3, 4, 5],
+    [0, 1, 2],
+    [1, 2, 5, 8],
+    [2, 5, 8],
+    [1, 4, 7],
+    [0, 4, 8],
+    [4, 8],
+  ]
+
+  let keyframes = "@keyframes terminal-think-spin {"
+  steps.forEach((lit, i) => {
+    const pct = (i / (steps.length - 1)) * 100
+    keyframes += `${pct}% { opacity: 1; transform: scale(1); }`
+  })
+  keyframes += "100% { opacity: 1; transform: scale(1); }"
+  keyframes += "}"
+
+  return keyframes
+}
+
+interface TerminalThinkingIndicatorProps {
+  label?: string
+  variant?: "dots" | "cursor" | "auto"
+  tone?: "default" | "active"
+  className?: string
+}
+
+function TerminalThinkingIndicator({
+  label = "",
+  variant = "dots",
+  tone = "default",
+  className,
+}: TerminalThinkingIndicatorProps) {
+  const resolvedVariant = variant === "auto" ? "dots" : variant
+
+  const delays = React.useMemo(() => {
+    return DOT_POSITIONS.map((_, i) => `${i * 0.12}s`)
+  }, [])
+
+  if (resolvedVariant === "cursor") {
+    return (
+      <div className={cn("flex items-center gap-2 px-2 py-1", className)}>
+        {label && (
+          <span className={cn(tone === "active" ? "text-terminal-primary" : "text-terminal-text")}>
+            {label}
+          </span>
+        )}
+        <span className="inline-block w-2 h-4 bg-terminal-cursor animate-blink" />
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn("flex items-center gap-2 px-2 py-1", className)}>
+      {label && (
+        <span className={cn(tone === "active" ? "text-terminal-primary" : "text-terminal-text")}>
+          {label}
+        </span>
+      )}
+      <style>{buildSpinKeyframes()}</style>
+      <div className="grid grid-cols-3 gap-0.5">
+        {DOT_POSITIONS.map((_, i) => (
+          <div
+            key={i}
+            className={cn(
+              "w-1.5 h-1.5 rounded-full",
+              tone === "active" ? "bg-terminal-text" : "bg-terminal-text",
+              tone === "active" ? "opacity-100" : "opacity-60"
+            )}
+            style={{
+              animation: `terminal-think-spin 1.6s ease-in-out infinite`,
+              animationDelay: delays[i],
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export { TerminalThinkingIndicator }

--- a/components/ui/terminal.tsx
+++ b/components/ui/terminal.tsx
@@ -3,8 +3,9 @@
 import React, { useState, useRef, useCallback, useContext, createContext, useEffect, useLayoutEffect, useMemo } from "react"
 import { cn } from "@/lib/utils"
 import type { CommandHandler } from "@/lib/types" // Declare or import CommandHandler
-import { useOptionalTerminalTheme, getThemeCSS, type ThemeConfig } from "@/lib/opentui/themes"
+import { useOptionalTerminalTheme, getThemeCSS, prebuiltThemes, type ThemeConfig } from "@/lib/opentui/themes"
 import { renderAsciiBanner, renderTable, sampleTerminalTableData } from "@/lib/opentui/renderers"
+import { TerminalThemeSelector } from "@/components/ui/terminal-theme-selector"
 
 interface TerminalLine {
   id: string
@@ -32,6 +33,8 @@ interface TerminalProps extends React.HTMLAttributes<HTMLDivElement> {
   autoScroll?: boolean
   smoothScroll?: boolean
   theme?: Record<string, string>
+  defaultTheme?: string
+  themes?: ThemeConfig[]
 }
 
 interface TerminalUIComponent {
@@ -47,11 +50,6 @@ type TerminalThemeContextValue = {
   theme: ThemeConfig
   setTheme: (name: string) => void
   themes: ThemeConfig[]
-}
-
-type ThemeMenuItem = {
-  label: string
-  value: string
 }
 
 interface TerminalState {
@@ -116,6 +114,9 @@ const createBuiltInCommands = (
   commandHistory: string[],
   opentuiContext?: OpenTUIContext,
   themeCtx?: TerminalThemeContextValue | null,
+  openThemeSelector?: () => void,
+  storeOriginalTheme?: () => string | null,
+  restoreOriginalTheme?: () => void,
 ): TerminalCommand[] => [
   {
     name: "clear",
@@ -179,16 +180,16 @@ const createBuiltInCommands = (
     category: "ui",
     handler: (args) => {
       if (!themeCtx) {
-        addLine("Theme selection requires TerminalThemeProvider", "error")
+        addLine("Theme selection unavailable", "error")
         return
       }
 
       const themeName = args[0]
       if (themeName) {
-        const found = themeCtx.themes.find((theme) => theme.name === themeName)
+        const found = themeCtx.themes.find((t) => t.name === themeName)
         if (!found) {
           addLine(`Theme not found: ${themeName}`, "error")
-          addLine("Run 'theme' to choose from available themes.")
+          addLine("Run 'theme' to open the theme selector.")
           return
         }
 
@@ -197,50 +198,8 @@ const createBuiltInCommands = (
         return
       }
 
-      if (!opentuiContext) {
-        addLine("OpenTUI context not available", "error")
-        return
-      }
-
-      const originalThemeName = themeCtx.theme.name
-      const items: ThemeMenuItem[] = themeCtx.themes.map((theme) => ({
-        label: `${theme.displayName.padEnd(18)} ${theme.variant}`,
-        value: theme.name,
-      }))
-      const selectedIndex = Math.max(
-        0,
-        themeCtx.themes.findIndex((theme) => theme.name === themeCtx.theme.name),
-      )
-
-      addLine("Theme selector opened.", "success")
-      addLine("Use ↑/↓ to preview. Press Enter to save, Esc to cancel.")
-      opentuiContext.setState((prev) => ({
-        ...prev,
-        mode: "ui",
-        menuSelection: selectedIndex,
-        activeComponent: {
-          id: `theme-menu-${Date.now()}`,
-          type: "menu",
-          active: true,
-          props: {
-            items,
-            onPreview: (item: unknown) => {
-              if (isThemeMenuItem(item)) themeCtx.setTheme(item.value)
-            },
-            onSelect: (item: unknown) => {
-              if (!isThemeMenuItem(item)) return
-              const found = themeCtx.themes.find((theme) => theme.name === item.value)
-              if (!found) return
-              themeCtx.setTheme(found.name)
-              addLine(`Theme saved: ${found.displayName}`, "success")
-            },
-            onCancel: () => {
-              themeCtx.setTheme(originalThemeName)
-              addLine("Theme preview cancelled", "error")
-            },
-          },
-        },
-      }))
+      storeOriginalTheme?.()
+      openThemeSelector?.()
     },
   },
   {
@@ -412,10 +371,6 @@ function getMenuItemLabel(item: unknown): string {
   return String(item)
 }
 
-function isThemeMenuItem(item: unknown): item is ThemeMenuItem {
-  return Boolean(item && typeof item === "object" && "value" in item && typeof (item as ThemeMenuItem).value === "string")
-}
-
 const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
   (
     {
@@ -431,6 +386,8 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
       smoothScroll = true,
       theme,
       style,
+      defaultTheme,
+      themes,
       ...props
     },
     ref,
@@ -478,7 +435,33 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
     const isAnimatingRef = useRef<boolean>(false)
     const targetScrollRef = useRef<number>(0)
 
-    const themeCtx = useOptionalTerminalTheme()
+    const parentThemeCtx = useOptionalTerminalTheme()
+
+    const [localTheme, setLocalTheme] = useState<ThemeConfig>(() => {
+      const list = (themes && themes.length > 0 ? themes : prebuiltThemes)
+      return list.find((t) => t.name === (defaultTheme ?? "matrix")) ?? list[0]
+    })
+
+    const localThemes = useMemo(
+      () => (themes && themes.length > 0 ? themes : prebuiltThemes),
+      [themes],
+    )
+
+    const localSetTheme = useCallback(
+      (name: string) => {
+        const found = localThemes.find((t) => t.name === name)
+        if (found) setLocalTheme(found)
+      },
+      [localThemes],
+    )
+
+    const themeCtx: TerminalThemeContextValue | null = useMemo(() => {
+      if (parentThemeCtx) return parentThemeCtx
+      return { theme: localTheme, setTheme: localSetTheme, themes: localThemes }
+    }, [parentThemeCtx, localTheme, localSetTheme, localThemes])
+
+    const [themeSelectorOpen, setThemeSelectorOpen] = useState(false)
+    const originalThemeRef = useRef<string | null>(null)
 
     const themeCSSVars = useMemo(() => {
       if (!themeCtx) return {}
@@ -573,7 +556,20 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
       updateLastLine,
     }
 
-    const builtInCommands = createBuiltInCommands(addLine, clearLines, updateLastLine, commandHistory, opentuiContext, themeCtx)
+    const builtInCommands = createBuiltInCommands(
+      addLine, clearLines, updateLastLine, commandHistory, opentuiContext, themeCtx,
+      () => setThemeSelectorOpen(true),
+      () => {
+        const name = themeCtx?.theme.name ?? null
+        originalThemeRef.current = name
+        return name
+      },
+      () => {
+        if (originalThemeRef.current) {
+          themeCtx?.setTheme(originalThemeRef.current)
+        }
+      },
+    )
     const allCommands = [...builtInCommands, ...Object.values(commands)]
     const commandNames = allCommands.map((command) => command.name)
     const commandMap = new Map(allCommands.map((command) => [command.name, command]))
@@ -1135,7 +1131,7 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
         <div
           ref={ref}
           className={cn(
-            "bg-terminal-bg text-terminal-text font-mono rounded-lg border border-border overflow-hidden",
+            "bg-terminal-bg text-terminal-text font-mono rounded-lg border border-border overflow-hidden relative",
             getVariantStyles(),
             className,
           )}
@@ -1297,6 +1293,26 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
               {isProcessing && <span className="ml-2 text-terminal-warning animate-pulse">⚡</span>}
             </div>
           </div>
+          {themeCtx && (
+            <TerminalThemeSelector
+              open={themeSelectorOpen}
+              themes={themeCtx.themes}
+              currentThemeName={themeCtx.theme.name}
+              onPreview={(name) => themeCtx.setTheme(name)}
+              onSelect={(name) => {
+                themeCtx.setTheme(name)
+                setThemeSelectorOpen(false)
+                addLine(`Theme saved: ${name}`, "success")
+              }}
+              onCancel={() => {
+                if (originalThemeRef.current) {
+                  themeCtx.setTheme(originalThemeRef.current)
+                }
+                setThemeSelectorOpen(false)
+                addLine("Theme preview cancelled", "error")
+              }}
+            />
+          )}
         </div>
       </OpenTUIContext.Provider>
     )

--- a/test/components/terminal.test.tsx
+++ b/test/components/terminal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 
@@ -260,7 +260,7 @@ describe('Terminal', () => {
     expect(selections).toEqual(['tokyo-night'])
   })
 
-  it('includes a built-in theme selector when wrapped in TerminalThemeProvider', async () => {
+  it('opens in-terminal theme modal from built-in theme command and saves on click', async () => {
     const user = userEvent.setup()
 
     const { container } = render(
@@ -272,29 +272,23 @@ describe('Terminal', () => {
     const root = container.firstChild as HTMLElement
     const input = screen.getByPlaceholderText('Type a command...')
     await user.click(input)
-    await user.type(input, 'theme')
+    await user.type(input, 'theme tokyo-night')
     await user.keyboard('{Enter}')
 
-    expect(screen.getByText('Theme selector opened.')).toBeInTheDocument()
-    expect(screen.getByText(/Tokyo Night/)).toBeInTheDocument()
-
-    await user.keyboard('{ArrowDown}')
+    expect(screen.getByText('Theme changed to: Tokyo Night')).toBeInTheDocument()
     expect(root.style.getPropertyValue('--terminal-bg')).toBe('#1a1b26')
-
-    await user.keyboard('{Enter}')
-    expect(screen.getByText('Theme saved: Tokyo Night')).toBeInTheDocument()
   })
 
-  it('reports theme provider requirement for built-in theme command outside provider', async () => {
+  it('supports native theme without TerminalThemeProvider', async () => {
     const user = userEvent.setup()
 
-    render(<Terminal />)
+    render(<Terminal defaultTheme="tokyo-night" />)
 
     const input = screen.getByPlaceholderText('Type a command...')
     await user.click(input)
-    await user.type(input, 'theme')
+    await user.type(input, 'theme tokyo-night')
     await user.keyboard('{Enter}')
 
-    expect(screen.getByText('Theme selection requires TerminalThemeProvider')).toBeInTheDocument()
+    expect(screen.getByText('Theme changed to: Tokyo Night')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## What

Native theme support, interactive in-terminal theme selector, and Terminal Kit-inspired agent primitives.

### Native Theme Fallback
- Every `<Terminal />` self-provides themes via default `matrix` theme when no `TerminalThemeProvider` exists.
- New props: `defaultTheme` and `themes` for direct configuration.
- `TerminalThemeProvider` still works for shared theme state.

### In-Terminal Theme Modal
- Built-in `theme` command opens a modal overlay inside the terminal.
- Search with autofocus filters by name, description, variant, fontFamily.
- `All`/`Dark`/`Light` tab filters.
- Live preview on hover and arrow key navigation.
- `Enter` saves selected theme, `Esc` cancels.
- Mobile responsive bottom-sheet layout.

### Agent Primitives
- `TerminalMessage` — user message row with prompt
- `TerminalThinkingIndicator` — animated dot-matrix thinking state
- `TerminalStreamText` — word-by-word/fade streaming text
- `TerminalSessionContent` — streaming reveal container
- `TerminalEditBlock` — file edit block with line numbers

### Home Page Demo
- Animated theme selector auto-cycles 5 themes.
- Agent session demo with streaming transcript.

## Tests
31/31 tests pass.