### PR TITLE
fix: in-terminal theme selector crash, focus leak, mobile sizing, and homepage slideshow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,37 +48,6 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
-function TerminalDemoCard({
-  title,
-  description,
-  commands,
-  welcomeMessage,
-}: {
-  title: string
-  description: string
-  commands: Record<string, CommandHandler>
-  welcomeMessage: string[]
-}) {
-  return (
-    <div className="rounded-lg border border-primary/30 bg-black shadow-lg shadow-primary/10 overflow-hidden">
-      <div className="flex items-center justify-between border-b border-primary/20 bg-black/80 px-4 py-2.5">
-        <span className="text-xs font-mono font-semibold text-primary">shadcn OpenTUI</span>
-        <span className="text-xs font-mono text-primary/50">{title}</span>
-      </div>
-      <Terminal commands={commands} welcomeMessage={welcomeMessage} className="h-[260px] bg-black" />
-      <div className="border-t border-primary/20 bg-black/80 px-4 py-2 text-xs text-primary/70">{description}</div>
-    </div>
-  )
-}
-
-function AnimatedThemeSelectorDemo() {
-  return (
-    <TerminalThemeProvider defaultTheme="matrix">
-      <AnimatedThemeSelectorDemoContent />
-    </TerminalThemeProvider>
-  )
-}
-
 function AnimatedThemeSelectorDemoContent() {
   const { theme: selectedTheme, setTheme } = useTerminalTheme()
   const [autoPreview, setAutoPreview] = useState(true)
@@ -169,6 +138,88 @@ function AnimatedThemeSelectorDemoContent() {
         className="h-[320px] rounded-none border-0 shadow-none"
         prompt="→"
       />
+    </div>
+  )
+}
+
+function LandingDemoShowcase() {
+  const [slide, setSlide] = useState<"theme" | "agent">("theme")
+
+  return (
+    <TerminalThemeProvider defaultTheme="matrix">
+      <div className="space-y-6">
+        <div className="flex justify-center gap-3">
+          <button
+            type="button"
+            onClick={() => setSlide("theme")}
+            className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-mono transition-all ${
+              slide === "theme"
+                ? "border-primary bg-primary/20 text-primary"
+                : "border-primary/30 text-muted-foreground hover:text-primary"
+            }`}
+          >
+            <WandSparkles className="w-4 h-4" />
+            Theme selection
+          </button>
+          <button
+            type="button"
+            onClick={() => setSlide("agent")}
+            className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-mono transition-all ${
+              slide === "agent"
+                ? "border-primary bg-primary/20 text-primary"
+                : "border-primary/30 text-muted-foreground hover:text-primary"
+            }`}
+          >
+            <TerminalIcon className="w-4 h-4" />
+            Agent session
+          </button>
+        </div>
+
+        {slide === "theme" ? <AnimatedThemeSelectorDemoContent /> : <AgentSlideWithAutoStart />}
+      </div>
+    </TerminalThemeProvider>
+  )
+}
+
+function AgentSlideWithAutoStart() {
+  const [started, setStarted] = useState(false)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setStarted(true), 600)
+    return () => clearTimeout(timer)
+  }, [])
+
+  if (!started) {
+    return (
+      <div className="rounded-2xl border border-primary/20 bg-black/50 p-12 text-center">
+        <div className="inline-flex items-center gap-2 text-terminal-muted">
+          <TerminalThinkingIndicator label="Starting session" />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-primary/20 bg-black/50 p-5 font-mono">
+      <div className="flex items-center gap-2 border-b border-terminal-border/30 px-2 py-1 text-xs text-terminal-muted">
+        <span className="font-semibold text-terminal-primary">agent session</span>
+      </div>
+      <TerminalSessionContent autoScroll streaming>
+        <TerminalMessage>/improve-the-ui</TerminalMessage>
+        <TerminalThinkingIndicator label="Thinking" />
+        <TerminalStreamText speed={60} mode="fade">
+          I&apos;ll improve the primary button hover — easing the opacity transition and adding a motion-safe press scale.
+        </TerminalStreamText>
+        <TerminalEditBlock
+          file="components/ui/button.tsx"
+          startLine={12}
+          highlightLines={[19, 20, 21]}
+          code={agentCode}
+        />
+        <TerminalStreamText speed={60} mode="fade">
+          Done — hover now eases to 90% opacity with a subtle press-in effect. Want me to apply the same pass to the secondary and ghost variants?
+        </TerminalStreamText>
+      </TerminalSessionContent>
     </div>
   )
 }
@@ -459,63 +510,7 @@ export default function Home() {
                 <p className="text-muted-foreground text-lg">Live shadcn terminal components running in the browser</p>
               </div>
 
-              <div className="grid md:grid-cols-3 gap-6">
-                <TerminalDemoCard
-                  title="Installation"
-                  description="Install and validate the stable shadcn terminal component."
-                  commands={{
-                    install: {
-                      name: "install",
-                      description: "Show install command",
-                      handler: (_args, context) => {
-                        context?.addLine?.("bunx shadcn@latest add terminal", "success")
-                        context?.addLine?.("Registry component ready.")
-                      },
-                    },
-                  }}
-                  welcomeMessage={["Install demo", "Try: install"]}
-                />
-                <TerminalDemoCard
-                  title="UI Components"
-                  description="Open forms and menus inside the stable terminal surface."
-                  commands={{
-                    menu: {
-                      name: "menu",
-                      description: "Open a menu",
-                      handler: (_args, context) => {
-                        context?.setState?.((prev: { menuSelection: number }) => ({
-                          ...prev,
-                          mode: "ui",
-                          menuSelection: 0,
-                          activeComponent: {
-                            id: `demo-menu-${Date.now()}`,
-                            type: "menu",
-                            props: { items: ["Dashboard", "Projects", "Settings"] },
-                            active: true,
-                          },
-                        }))
-                      },
-                    },
-                  }}
-                  welcomeMessage={["UI demo", "Try: menu"]}
-                />
-                <TerminalDemoCard
-                  title="Built-in Commands"
-                  description="Command history, completions, async handlers, and terminal output."
-                  commands={{
-                    status: {
-                      name: "status",
-                      description: "Show status",
-                      handler: (_args, context) => {
-                        context?.addLine?.("Terminal mounted", "success")
-                        context?.addLine?.("Commands active: help, clear, status")
-                      },
-                    },
-                  }}
-                  welcomeMessage={["Commands demo", "Try: status", "Try: help"]}
-                />
-                <AnimatedThemeSelectorDemo />
-              </div>
+              <LandingDemoShowcase />
             </div>
           </section>
 

--- a/components/ui/terminal-theme-selector.tsx
+++ b/components/ui/terminal-theme-selector.tsx
@@ -40,14 +40,20 @@ export function TerminalThemeSelector({
     }
     if (query.trim()) {
       const q = query.toLowerCase().trim()
-      result = result.filter(
-        (t) =>
-          t.name.toLowerCase().includes(q) ||
-          t.displayName.toLowerCase().includes(q) ||
-          t.description.toLowerCase().includes(q) ||
-          t.variant.toLowerCase().includes(q) ||
-          (t.fontFamily && t.fontFamily.toLowerCase().includes(q)),
-      )
+      result = result.filter((t) => {
+        const name = t.name ?? ""
+        const displayName = t.displayName ?? ""
+        const description = t.description ?? ""
+        const variant = t.variant ?? ""
+        const fontFamily = t.fontFamily ?? ""
+        return (
+          name.toLowerCase().includes(q) ||
+          displayName.toLowerCase().includes(q) ||
+          description.toLowerCase().includes(q) ||
+          variant.toLowerCase().includes(q) ||
+          fontFamily.toLowerCase().includes(q)
+        )
+      })
     }
     return result
   }, [themes, filterTab, query])
@@ -88,19 +94,22 @@ export function TerminalThemeSelector({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      const isSearchFocused = document.activeElement === searchRef.current
       switch (e.key) {
         case "ArrowDown":
           e.preventDefault()
-          setSelectedIndex((prev) => Math.min(prev + 1, filtered.length - 1))
+          if (filtered.length > 0) {
+            setSelectedIndex((prev) => Math.min(prev + 1, filtered.length - 1))
+          }
           break
         case "ArrowUp":
           e.preventDefault()
-          setSelectedIndex((prev) => Math.max(prev - 1, 0))
+          if (filtered.length > 0) {
+            setSelectedIndex((prev) => Math.max(prev - 1, 0))
+          }
           break
         case "Enter":
           e.preventDefault()
-          if (filtered[selectedIndex]) {
+          if (filtered.length > 0 && filtered[selectedIndex]) {
             onSelect(filtered[selectedIndex].name)
           }
           break
@@ -117,20 +126,14 @@ export function TerminalThemeSelector({
 
   return (
     <div
-      className="absolute inset-0 z-50 flex items-center justify-center sm:p-4"
+      className="absolute inset-0 z-50 flex items-center justify-center p-2 sm:p-4"
       onKeyDown={handleKeyDown}
     >
       {/* backdrop */}
       <div className="absolute inset-0 bg-terminal-bg/95 backdrop-blur-sm" />
 
-      {/* mobile bottom sheet */}
-      <div
-        className={cn(
-          "relative flex flex-col",
-          "sm:max-w-[560px] sm:w-full sm:max-h-[80vh] sm:rounded-lg sm:border sm:border-terminal-border sm:bg-terminal-bg",
-          "fixed sm:static bottom-0 left-0 right-0 max-h-[85%] rounded-t-xl border-t border-terminal-border bg-terminal-bg sm:border-t",
-        )}
-      >
+      {/* panel */}
+      <div className="relative flex w-full max-h-full flex-col overflow-hidden rounded-lg border border-terminal-border bg-terminal-bg sm:max-h-[80vh] sm:max-w-[560px]">
         {/* header: search */}
         <div className="relative flex-shrink-0 border-b border-terminal-border">
           <div className="absolute left-3 top-1/2 -translate-y-1/2 text-terminal-muted">

--- a/components/ui/terminal.tsx
+++ b/components/ui/terminal.tsx
@@ -556,9 +556,15 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
       updateLastLine,
     }
 
+    const selectorJustOpenedRef = useRef(false)
+    const openThemeSelectorWithRef = useCallback(() => {
+      selectorJustOpenedRef.current = true
+      setThemeSelectorOpen(true)
+    }, [])
+
     const builtInCommands = createBuiltInCommands(
       addLine, clearLines, updateLastLine, commandHistory, opentuiContext, themeCtx,
-      () => setThemeSelectorOpen(true),
+      openThemeSelectorWithRef,
       () => {
         const name = themeCtx?.theme.name ?? null
         originalThemeRef.current = name
@@ -581,7 +587,7 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
         ? `${opentuiState[0].mode.toUpperCase()} mode - ESC to exit`
         : "Type a command..."
     const canShowCompletions =
-      opentuiState[0].mode === "command" && !isProcessing && currentInput.trim().length > 0 && argsPart.length === 0
+      !themeSelectorOpen && opentuiState[0].mode === "command" && !isProcessing && currentInput.trim().length > 0 && argsPart.length === 0
     const completionSuggestions: CommandCompletion[] = canShowCompletions
       ? allCommands
           .filter((command) => command.name.startsWith(commandPart))
@@ -684,10 +690,13 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
 
       try {
         await processCommand(command)
-      } finally {
+      }       finally {
         setIsProcessing(false)
         setTimeout(() => {
-          inputRef.current?.focus()
+          if (!selectorJustOpenedRef.current) {
+            inputRef.current?.focus()
+          }
+          selectorJustOpenedRef.current = false
         }, 0)
       }
     }
@@ -1242,7 +1251,7 @@ const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
                       setCursorPosition(inputRef.current.selectionStart || 0)
                     }
                   }}
-                  disabled={isProcessing}
+                  disabled={isProcessing || themeSelectorOpen}
                   className="w-full bg-transparent border-none font-mono text-sm text-transparent caret-transparent outline-none sm:text-base"
                   autoComplete="off"
                   spellCheck={false}

--- a/test/components/terminal.test.tsx
+++ b/test/components/terminal.test.tsx
@@ -291,4 +291,67 @@ describe('Terminal', () => {
 
     expect(screen.getByText('Theme changed to: Tokyo Night')).toBeInTheDocument()
   })
+
+  it('does not crash when searching themes from the in-terminal selector', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TerminalThemeProvider defaultTheme="matrix">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+
+    const input = screen.getByPlaceholderText('Type a command...')
+    await user.click(input)
+    await user.type(input, 'theme')
+    await user.keyboard('{Enter}')
+
+    const search = await screen.findByPlaceholderText('Search themes...')
+    await user.type(search, 'tokyo')
+
+    expect(screen.getByPlaceholderText('Search themes...')).toBeInTheDocument()
+    expect(screen.getByText('Tokyo Night')).toBeInTheDocument()
+  })
+
+  it('disables terminal command input while theme selector is open', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TerminalThemeProvider defaultTheme="matrix">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+
+    const input = screen.getByPlaceholderText('Type a command...')
+    await user.click(input)
+    await user.type(input, 'theme')
+    await user.keyboard('{Enter}')
+
+    expect(await screen.findByPlaceholderText('Search themes...')).toBeInTheDocument()
+    expect(input).toBeDisabled()
+  })
+
+  it('handles empty search results safely without crash', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TerminalThemeProvider defaultTheme="matrix">
+        <Terminal />
+      </TerminalThemeProvider>,
+    )
+
+    const input = screen.getByPlaceholderText('Type a command...')
+    await user.click(input)
+    await user.type(input, 'theme')
+    await user.keyboard('{Enter}')
+
+    const search = await screen.findByPlaceholderText('Search themes...')
+    await user.type(search, 'zzzz-no-match')
+
+    expect(screen.getByText('No themes found')).toBeInTheDocument()
+
+    await user.keyboard('{ArrowDown}{ArrowUp}{Enter}{Escape}')
+
+    expect(screen.queryByPlaceholderText('Search themes...')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Changes

- **terminal-theme-selector.tsx**: safe string coercion in search filter (no crash on undefined fields), clamp keyboard nav when no results, streamlined mobile panel layout
- **terminal.tsx**: disable command completions and input while selector open, prevent post-command focus steal when selector opens
- **page.tsx**: replace three mini TerminalDemoCard cards + standalone theme demo with one polished 2-slide LandingDemoShowcase (theme selection → agent session)
- **terminal.test.tsx**: 3 new regression tests for crash safety, focus isolation, and empty search navigation

## Verification

- `bun vitest run test/components/test-theme-vars.test.tsx test/components/terminal.test.tsx` → 34/34 passed
- No new TypeScript errors